### PR TITLE
generation path of client entities i18n translation updated

### DIFF
--- a/generators/entity-i18n/files.js
+++ b/generators/entity-i18n/files.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2013-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const utils = require('generator-jhipster/generators/utils');
+const utilsNet = require('../utils');
+
+function writeFiles() {
+    return {
+        writeEnumFiles() {
+            this.fields.forEach(field => {
+                if (field.fieldIsEnum === true) {
+                    const enumInfo = utils.buildEnumInfo(field, this.angularAppName, this.packageName, this.clientRootFolder);
+
+                    // Copy for each
+                    if (!this.skipClient && this.enableTranslation) {
+                        const languages = this.languages || this.getAllInstalledLanguages();
+                        languages.forEach(language => {
+                            utilsNet.copyEnumI18n.call(this, language, enumInfo, this.fetchFromInstalledJHipster('entity-i18n/templates'));
+                        });
+                    }
+                }
+            });
+        },
+
+        writeClientFiles() {
+            if (this.skipClient) return;
+
+            // Copy for each
+            if (this.enableTranslation) {
+                const languages = this.languages || this.getAllInstalledLanguages();
+                languages.forEach(language => {
+                    utilsNet.copyI18n.call(this, language, this.fetchFromInstalledJHipster('entity-i18n/templates'));
+                });
+            }
+        }
+    };
+}
+
+module.exports = {
+    writeFiles
+};

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2013-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable consistent-return */
+const chalk = require('chalk');
+const EntityI18nGenerator = require('generator-jhipster/generators/entity-i18n');
+
+const writeFiles = require('./files').writeFiles;
+
+module.exports = class extends EntityI18nGenerator {
+    constructor(args, opts) {
+        super(args, Object.assign({ fromBlueprint: true }, opts)); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error(`This is a JHipster blueprint and should be used only like ${chalk.yellow('jhipster --blueprint dotnetcore')}`);
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+    }
+
+    get writing() {
+        return writeFiles();
+    }
+};

--- a/generators/entity-server/templates/dotnetcore/src/Project/Controllers/EntityController.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/src/Project/Controllers/EntityController.cs.ejs
@@ -77,7 +77,7 @@ namespace <%= namespace %>.Controllers {
             if (<%= camelCasedEntityClass %>.Id == 0) throw new BadRequestAlertException("Invalid Id", EntityName, "idnull");
             //TODO catch //DbUpdateConcurrencyException into problem
             <%_ relationships.forEach( relationship => {
-                if (relationship.relationshipType === 'many-to-many') { _%>
+                if (relationship.relationshipType === 'many-to-many' && relationship.ownerSide) { _%>
             _applicationDatabaseContext.<%= relationship.joinEntityFieldNamePascalizedPlural %>.RemoveNavigationProperty(<%= camelCasedEntityClass %>, <%= camelCasedEntityClass %>.Id);
                 <%_ }
             }); _%>
@@ -86,15 +86,13 @@ namespace <%= namespace %>.Controllers {
             let suffix = 0;
             relationships.forEach( relationship => {
                 if (!relationship.relationshipValidateRules || !relationship.relationshipValidateRules.includes('required')) {
-                    if (first) {_%>
+                    if (relationship.relationshipType === 'one-to-one' || relationship.relationshipType === 'many-to-one') {
+                        if (first) { _%>
             /* Force the reference navigation property to be in "modified" state.
             This allows to modify it with a null value (the field is nullable).
             This takes into consideration the case of removing the association between the two instances. */
-                        <%_ first = false;
-                    }
-                    if (relationship.relationshipType === 'many-to-many' || relationship.relationshipType === 'one-to-many') { _%>
-            _applicationDatabaseContext.Entry(<%= camelCasedEntityClass %>).Reference(<%= camelCasedEntityClass + suffix %> => <%= camelCasedEntityClass + suffix %>.<%= relationship.relationshipFieldNamePascalizedPlural %>).IsModified = true;
-                <%_ } else { _%>
+                            <%_ first = false;
+                        } _%>
             _applicationDatabaseContext.Entry(<%= camelCasedEntityClass %>).Reference(<%= camelCasedEntityClass + suffix %> => <%= camelCasedEntityClass + suffix %>.<%= relationship.relationshipFieldNamePascalized %>).IsModified = true;
                 <%_ }
                 }

--- a/generators/entity-server/templates/dotnetcore/test/Project.Test/Controllers/EntityResourceIntTest.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/test/Project.Test/Controllers/EntityResourceIntTest.cs.ejs
@@ -185,7 +185,7 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace <%= namespace %>.Test.Web.Rest {
+namespace <%= namespace %>.Test.Controllers {
     public class <%= pascalizedEntityClass %>ResourceIntTest {
         public <%= pascalizedEntityClass %>ResourceIntTest()
         {
@@ -240,7 +240,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             var databaseSizeBeforeCreate = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.Count();
 
             // Create the <%= pascalizedEntityClass %>
-            var response = await _client.PostAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PostAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.Created);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -261,7 +261,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             _<%= camelCasedEntityClass %>.Id = 1L;
 
             // An entity with an existing ID cannot be created, so this API call must fail
-            var response = await _client.PostAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PostAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -312,7 +312,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = <%= relationship.otherEntityNameCamelCased %>;
 
             // Create the <%= pascalizedEntityClass %>
-            var response = await _client.PostAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PostAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.Created);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -372,14 +372,14 @@ namespace <%= namespace %>.Test.Web.Rest {
             _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
 
             // Create the <%= pascalizedEntityClass %>
-            var response = await _client.PostAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PostAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             <%_ } else { _%>
             var databaseSizeBeforeCreate = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.Count();
 
             /* Due to JsonIgnore annotation on <%= relationship.relationshipFieldNamePascalizedPlural %> property, we first create the <%= pascalizedEntityClass %>
                This allows the <%= relationship.otherEntityNameCamelCased %> to create the relationship */
-            var response = await _client.PostAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PostAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             var <%= camelCasedEntityClass %> = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.ToList()[0];
 
@@ -468,7 +468,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             _<%= camelCasedEntityClass %>.<%= field.fieldNamePascalized %> = null;
 
             // Create the <%= pascalizedEntityClass %>, which fails.
-            var response = await _client.PostAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PostAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
             var <%= camelCasedEntityClass %>List = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.ToList();
@@ -485,7 +485,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             await _applicationDatabaseContext.SaveChangesAsync();
 
             // Get all the <%= camelCasedEntityClass %>List
-            var response = await _client.GetAsync("/api/<%= snakeCasedEntityClassPlural %>?sort=id,desc");
+            var response = await _client.GetAsync("/api/<%= kebabCasedEntityClassPlural %>?sort=id,desc");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var json = JToken.Parse(await response.Content.ReadAsStringAsync());
@@ -503,7 +503,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             await _applicationDatabaseContext.SaveChangesAsync();
 
             // Get the <%= camelCasedEntityClass %>
-            var response = await _client.GetAsync($"/api/<%= snakeCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
+            var response = await _client.GetAsync($"/api/<%= kebabCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var json = JToken.Parse(await response.Content.ReadAsStringAsync());
@@ -516,7 +516,7 @@ namespace <%= namespace %>.Test.Web.Rest {
         [Fact]
         public async Task GetNonExisting<%= pascalizedEntityClass %>()
         {
-            var response = await _client.GetAsync("/api/<%= snakeCasedEntityClassPlural %>/" + long.MaxValue);
+            var response = await _client.GetAsync("/api/<%= kebabCasedEntityClassPlural %>/" + long.MaxValue);
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
@@ -538,7 +538,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             updated<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %> = Updated<%= field.fieldNamePascalized %>;
             <%_ }); _%>
 
-            var response = await _client.PutAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
+            var response = await _client.PutAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -556,7 +556,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             var databaseSizeBeforeUpdate = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.Count();
 
             // If the entity doesn't have an ID, it will throw BadRequestAlertException
-            var response = await _client.PutAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
+            var response = await _client.PutAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(_<%= camelCasedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -645,7 +645,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             <%_ }); _%>
             updated<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = updated<%= relationship.otherEntityNamePascalized %>;
 
-            var response = await _client.PutAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
+            var response = await _client.PutAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -765,7 +765,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             <%_ }); _%>
             updated<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = null;
 
-            var response = await _client.PutAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
+            var response = await _client.PutAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Validate the <%= pascalizedEntityClass %> in the database
@@ -884,7 +884,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             updated<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalizedPlural %>.Clear();
             updated<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalizedPlural %>.Add(updated<%= relationship.otherEntityNamePascalized %>);
 
-            var response = await _client.PutAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
+            var response = await _client.PutAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             <%_ } else { _%>
             /* Due to JsonIgnore annotation on <%= relationship.relationshipFieldNamePascalizedPlural %> property, we first create the <%= pascalizedEntityClass %>
@@ -931,7 +931,7 @@ namespace <%= namespace %>.Test.Web.Rest {
             updated<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %> = Updated<%= field.fieldNamePascalized %>;
             <%_ }); _%>
 
-            var response = await _client.PutAsync("/api/<%= snakeCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
+            var response = await _client.PutAsync("/api/<%= kebabCasedEntityClassPlural %>", TestUtil.ToJsonContent(updated<%= pascalizedEntityClass %>));
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Create a second <%= relationship.otherEntityNamePascalized %> to update the ManyToMany association
@@ -1043,7 +1043,7 @@ namespace <%= namespace %>.Test.Web.Rest {
 
             var databaseSizeBeforeDelete = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.Count();
 
-            var response = await _client.DeleteAsync($"/api/<%= snakeCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
+            var response = await _client.DeleteAsync($"/api/<%= kebabCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Validate the database is empty
@@ -1093,7 +1093,7 @@ namespace <%= namespace %>.Test.Web.Rest {
 
             var databaseSizeBeforeDelete = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.Count();
 
-            var response = await _client.DeleteAsync($"/api/<%= snakeCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
+            var response = await _client.DeleteAsync($"/api/<%= kebabCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Validate the database is empty
@@ -1203,7 +1203,7 @@ namespace <%= namespace %>.Test.Web.Rest {
 
             var databaseSizeBeforeDelete = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.Count();
 
-            var response = await _client.DeleteAsync($"/api/<%= snakeCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
+            var response = await _client.DeleteAsync($"/api/<%= kebabCasedEntityClassPlural %>/{_<%= camelCasedEntityClass %>.Id}");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Validate the database is empty

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -93,6 +93,8 @@ module.exports = class extends EntityGenerator {
                 context.toPascalCase = toPascalCase;
                 context.pluralize = pluralize;
                 context._ = _;
+                context.mainAngularDir = `${context.mainProjectDir}/ClientApp/app`;
+                context.mainClientDir = `${context.mainProjectDir}/ClientApp`;
 
                 // Load in-memory data for .Net Blueprint fields
                 context.fields.forEach(field => {

--- a/generators/server/templates/dotnetcore/test/Project.Test/Controllers/AccountResourceIntTest.cs.ejs
+++ b/generators/server/templates/dotnetcore/test/Project.Test/Controllers/AccountResourceIntTest.cs.ejs
@@ -31,7 +31,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace <%= namespace %>.Test.Web.Rest {
+namespace <%= namespace %>.Test.Controllers {
     public class AccountResourceIntTest {
         public AccountResourceIntTest()
         {

--- a/generators/server/templates/dotnetcore/test/Project.Test/Controllers/TestUtil.cs.ejs
+++ b/generators/server/templates/dotnetcore/test/Project.Test/Controllers/TestUtil.cs.ejs
@@ -19,7 +19,7 @@ using System.Text;
 using FluentAssertions;
 using Newtonsoft.Json;
 
-namespace <%= namespace %>.Test.Web.Rest {
+namespace <%= namespace %>.Test.Controllers {
     public static class TestUtil {
         private static readonly Random random = new Random();
 

--- a/generators/server/templates/dotnetcore/test/Project.Test/Controllers/UserJwtControllerIntTest.cs.ejs
+++ b/generators/server/templates/dotnetcore/test/Project.Test/Controllers/UserJwtControllerIntTest.cs.ejs
@@ -25,7 +25,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace <%= namespace %>.Test.Web.Rest {
+namespace <%= namespace %>.Test.Controllers {
     public class UserJwtControllerIntTest {
         public UserJwtControllerIntTest()
         {

--- a/generators/server/templates/dotnetcore/test/Project.Test/Controllers/UserResourceIntTest.cs.ejs
+++ b/generators/server/templates/dotnetcore/test/Project.Test/Controllers/UserResourceIntTest.cs.ejs
@@ -28,7 +28,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace <%= namespace %>.Test.Web.Rest {
+namespace <%= namespace %>.Test.Controllers {
     public class UserResourceIntTest {
         public UserResourceIntTest()
         {

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2013-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const constants = require('./generator-dotnetcore-constants');
+
+const SERVER_SRC_DIR = constants.SERVER_SRC_DIR;
+
+module.exports = {
+    copyI18n,
+    copyEnumI18n
+}
+
+/**
+ * Copy I18N
+ *
+ * @param language
+ * @param prefix
+ */
+function copyI18n(language, prefix = '') {
+    try {
+        const fileName = this.entityTranslationKey;
+        this.template(
+            `${prefix ? `${prefix}/` : ''}i18n/entity_${language}.json.ejs`,
+            `${SERVER_SRC_DIR}${this.mainClientDir}/i18n/${language}/${fileName}.json`
+        );
+        this.addEntityTranslationKey(this.entityTranslationKeyMenu, this.entityClass, language);
+    } catch (e) {
+        this.debug('Error:', e);
+        // An exception is thrown if the folder doesn't exist
+        // do nothing
+    }
+}
+
+/**
+ * Copy Enum I18N
+ *
+ * @param language
+ * @param enumInfo
+ * @param prefix
+ */
+function copyEnumI18n(language, enumInfo, prefix = '') {
+    try {
+        this.template(
+            `${prefix ? `${prefix}/` : ''}i18n/enum.json.ejs`,
+            `${SERVER_SRC_DIR}${this.mainClientDir}/i18n/${language}/${enumInfo.clientRootFolder}${enumInfo.enumInstance}.json`,
+            this,
+            {},
+            enumInfo
+        );
+    } catch (e) {
+        this.debug('Error:', e);
+        // An exception is thrown if the folder doesn't exist
+        // do nothing
+    }
+}


### PR DESCRIPTION
client entity-i18n generation is now done at the right path corresponding to the .Net C# file tree
+
fix of a typo et a minor issue :
- fix of a generation issue in the put operation in controller template
- fix of a namespace issue when generating the controllers tests