### PR TITLE
Fix the case when generating the tests of an entity, the associated entities were not yet generated

### DIFF
--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -90,6 +90,10 @@ const serverFiles = {
                     file: 'Project.Test/Controllers/EntityResourceIntTest.cs',
                     renameTo: generator =>
                         `${generator.testProjectDir}/Controllers/${generator.asEntity(generator.entityClass)}ResourceIntTest.cs`
+                },
+                {
+                    file: 'Project.Test/Setup/AssociatedEntityFactories.cs',
+                    renameTo: generator => `${generator.testProjectDir}/Setup/AssociatedEntityFactories.cs`
                 }
             ]
         }

--- a/generators/entity-server/templates/dotnetcore/src/Project/Data/ApplicationDatabaseContext.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/src/Project/Data/ApplicationDatabaseContext.cs.ejs
@@ -36,9 +36,9 @@ namespace <%= namespace %>.Data {
                 <%_ entity.definition.relationships.forEach(relationship => {
                     if (relationship.relationshipType === 'many-to-many') {
                         if (relationship.ownerSide) {
-                            let entityClassNamePascalized = entity.name;
-                            let otherEntityClassNamePascalized = toPascalCase(relationship.otherEntityName);
-                            let joinEntityClassNamePascalized = entityClassNamePascalized + otherEntityClassNamePascalized; _%>
+                            let relationshipNamePascalized = toPascalCase(relationship.relationshipName);
+                            let otherEntityRelationshipNamePascalized = toPascalCase(relationship.otherEntityRelationshipName);
+                            let joinEntityClassNamePascalized = otherEntityRelationshipNamePascalized + relationshipNamePascalized; _%>
         public DbSet<<%= joinEntityClassNamePascalized %>> <%= pluralize(joinEntityClassNamePascalized) %> { get; set; }
                         <%_ }
                     }
@@ -83,13 +83,15 @@ namespace <%= namespace %>.Data {
                     entity.definition.relationships.forEach(relationship => {
                         if (relationship.relationshipType === 'many-to-many') {
                             if (relationship.ownerSide) {
+                                let relationshipNamePascalized = toPascalCase(relationship.relationshipName);
+                                let otherEntityRelationshipNamePascalized = toPascalCase(relationship.otherEntityRelationshipName);
+                                let joinEntityClassNamePascalized = otherEntityRelationshipNamePascalized + relationshipNamePascalized;
                                 let entityClassNamePascalized = entity.name;
                                 let otherEntityClassNamePascalized = toPascalCase(relationship.otherEntityName);
-                                let joinEntityClassNamePascalized = entityClassNamePascalized + otherEntityClassNamePascalized;
                                 let ownerRelationshipFieldName = entityClassNamePascalized;
                                 let nonOwnerRelationshipFieldName = otherEntityClassNamePascalized; _%>
             builder.Entity<<%= joinEntityClassNamePascalized %>>()
-                .HasKey(t => new { t.<%= ownerRelationshipFieldName %>Id, t.<%= toPascalCase(nonOwnerRelationshipFieldName) %>Id });
+                .HasKey(t => new { t.<%= ownerRelationshipFieldName %>Id, t.<%= nonOwnerRelationshipFieldName %>Id });
 
                             <%_ }
                         }

--- a/generators/entity-server/templates/dotnetcore/test/Project.Test/Controllers/EntityResourceIntTest.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/test/Project.Test/Controllers/EntityResourceIntTest.cs.ejs
@@ -172,6 +172,9 @@ function hasManyToOneOrManyToManyWithDateTimeTypeField() {
 }
 if (hasDateTimeTypeField() || hasManyToOneOrManyToManyWithDateTimeTypeField()) { _%>
 using System;
+<%_ }
+if (entityClassHasManyToOne || entityClassHasManyToMany) { _%>
+using System.Collections.Generic;
 <%_ } _%>
 using System.Linq;
 using System.Net;
@@ -272,36 +275,14 @@ namespace <%= namespace %>.Test.Controllers {
         <%_ relationships.forEach(relationship => {
             if (relationship.relationshipType === 'many-to-one') { _%>
         [Fact]
-        public async Task Create<%= pascalizedEntityClass %>WithExistingReferenced<%= relationship.otherEntityNamePascalized %>()
+        public async Task Create<%= pascalizedEntityClass %>WithExistingReferenced<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>Relationship()
         {
             <%_ if (relationship.otherEntityName.toUpperCase() === 'USER' || relationship.otherEntityName.toUpperCase() === 'USERROLE' || relationship.otherEntityName.toUpperCase() === 'ROLE') { _%>
             // Get a <%= relationship.otherEntityNamePascalized %> to referenced
             var <%= relationship.otherEntityNameCamelCased %> = _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.ToList()[0];
             <%_ } else { _%>
             // Create a <%= relationship.otherEntityNamePascalized %> to referenced
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ let j = 0;
-                let found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
             <%_ } _%>
@@ -329,6 +310,17 @@ namespace <%= namespace %>.Test.Controllers {
             test<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %>.Should().Be(Default<%= field.fieldNamePascalized %>);
             <%_ }); _%>
             test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>);
+
+            <%_ if (relationship.otherEntityName.toUpperCase() !== 'USER' && relationship.otherEntityName.toUpperCase() !== 'USERROLE' && relationship.otherEntityName.toUpperCase() !== 'ROLE') { _%>
+            // Validate the <%= relationship.otherEntityNamePascalized %> in the database
+            var test<%= relationship.otherEntityNamePascalized %> = await _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>
+                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
+            test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>[0].Should().Be(test<%= pascalizedEntityClass %>);
+            <%_ } _%>
         }
 
             <%_ }
@@ -336,33 +328,11 @@ namespace <%= namespace %>.Test.Controllers {
         <%_ relationships.forEach(relationship => {
             if (relationship.relationshipType === 'many-to-many') { _%>
         [Fact]
-        public async Task Create<%= pascalizedEntityClass%>WithManyToManyAssociationWith<%= relationship.otherEntityNamePascalized %>()
+        public async Task Create<%= pascalizedEntityClass%>WithManyToManyAssociationReferencing<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>Relationship()
         {
             <%_ if (relationship.ownerSide) { _%>
             // Create a <%= relationship.otherEntityNamePascalized %> to test the ManyToMany association
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
 
@@ -384,29 +354,7 @@ namespace <%= namespace %>.Test.Controllers {
             var <%= camelCasedEntityClass %> = _applicationDatabaseContext.<%= pascalizedEntityClassPlural %>.ToList()[0];
 
             // Create an <%= relationship.otherEntityNamePascalized %> to test the ManyToMany association
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             <%= relationship.otherEntityNameCamelCased %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Add(<%= camelCasedEntityClass %>);
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
@@ -431,21 +379,8 @@ namespace <%= namespace %>.Test.Controllers {
                     .ThenInclude(<%= relationship.joinEntityNameCamelCased %> => <%= relationship.joinEntityNameCamelCased %>.<%= pascalizedEntityClass %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            test<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>[0].Should().Be(test<%= pascalizedEntityClass %>);
         }
 
@@ -567,7 +502,7 @@ namespace <%= namespace %>.Test.Controllers {
         <%_ relationships.forEach(relationship => {
             if (relationship.relationshipType === 'many-to-one') { _%>
         [Fact]
-        public async Task Update<%= pascalizedEntityClass %>WithExistingReferenced<%= relationship.otherEntityNamePascalized %>()
+        public async Task Update<%= pascalizedEntityClass %>WithExistingReferenced<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>Relationship()
         {
             <%_ if (relationship.otherEntityName.toUpperCase() === 'USER' || relationship.otherEntityName.toUpperCase() === 'USERROLE' || relationship.otherEntityName.toUpperCase() === 'ROLE') { _%>
             // Get two <%= relationship.otherEntityNamePascalizedPlural %> to referenced
@@ -575,52 +510,8 @@ namespace <%= namespace %>.Test.Controllers {
             var updated<%= relationship.otherEntityNamePascalized %> = _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.ToList()[1];
             <%_ } else { _%>
             // Create two <%= relationship.otherEntityNamePascalizedPlural %> to referenced
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
-            var updated<%= relationship.otherEntityNamePascalized %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
+            var updated<%= relationship.otherEntityNamePascalized %> = AssociatedEntityFactories.getUpdatedAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(updated<%= relationship.otherEntityNamePascalized %>);
             await _applicationDatabaseContext.SaveChangesAsync();
@@ -663,46 +554,20 @@ namespace <%= namespace %>.Test.Controllers {
 
             // Validate the updated<%= relationship.otherEntityNamePascalized %> in the database
             var testUpdated<%= relationship.otherEntityNamePascalized %> = await _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>
-                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= pascalizedEntityClassPlural %>)
+                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == updated<%= relationship.otherEntityNamePascalized %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            testUpdated<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(updated<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
-            testUpdated<%= relationship.otherEntityNamePascalized %>.<%= pascalizedEntityClassPlural %>[0].Should().Be(test<%= pascalizedEntityClass %>);
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(testUpdated<%= relationship.otherEntityNamePascalized %>, updated<%= relationship.otherEntityNamePascalized %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
+            testUpdated<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>[0].Should().Be(test<%= pascalizedEntityClass %>);
 
             // Validate the <%= relationship.otherEntityNameCamelCased %> in the database
             var test<%= relationship.otherEntityNamePascalized %> = await _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>
-                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= pascalizedEntityClassPlural %>)
+                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            test<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Should().BeEmpty();
             <%_ } _%>
         }
@@ -712,36 +577,14 @@ namespace <%= namespace %>.Test.Controllers {
         <%_ relationships.forEach(relationship => {
             if (relationship.relationshipType === 'many-to-one' && !relationship.relationshipRequired) { _%>
         [Fact]
-        public async Task Update<%= pascalizedEntityClass %>WithReferenced<%= relationship.otherEntityNamePascalized %>ToNull()
+        public async Task Update<%= pascalizedEntityClass %>WithReferenced<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>RelationshipToNull()
         {
             <%_ if (relationship.otherEntityName.toUpperCase() === 'USER' || relationship.otherEntityName.toUpperCase() === 'USERROLE' || relationship.otherEntityName.toUpperCase() === 'ROLE') { _%>
             // Get a <%= relationship.otherEntityNamePascalized %> to referenced
             var <%= relationship.otherEntityNameCamelCased %> = _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.ToList()[0];
             <%_ } else { _%>
             // Create a <%= relationship.otherEntityNamePascalized %> to referenced
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
             <%_ } _%>
@@ -783,24 +626,11 @@ namespace <%= namespace %>.Test.Controllers {
 
             // Validate the <%= relationship.otherEntityNameCamelCased %> in the database
             var test<%= relationship.otherEntityNamePascalized %> = await _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>
-                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= pascalizedEntityClassPlural %>)
+                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            test<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Should().BeEmpty();
             <%_ } _%>
         }
@@ -810,56 +640,12 @@ namespace <%= namespace %>.Test.Controllers {
         <%_ relationships.forEach(relationship => {
             if (relationship.relationshipType === 'many-to-many') { _%>
         [Fact]
-        public async Task Update<%= pascalizedEntityClass%>WithManyToManyAssociationWith<%= relationship.otherEntityNamePascalized %>()
+        public async Task Update<%= pascalizedEntityClass%>WithManyToManyAssociationReferencing<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>Relationship()
         {
             <%_ if (relationship.ownerSide) { _%>
             // Create two <%= relationship.otherEntityNamePascalizedPlural %> to test the ManyToMany association
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
-            var updated<%= relationship.otherEntityNamePascalized %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
+            var updated<%= relationship.otherEntityNamePascalized %> = AssociatedEntityFactories.getUpdatedAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(updated<%= relationship.otherEntityNamePascalized %>);
             await _applicationDatabaseContext.SaveChangesAsync();
@@ -893,29 +679,7 @@ namespace <%= namespace %>.Test.Controllers {
             await _applicationDatabaseContext.SaveChangesAsync();
 
             // Create an <%= relationship.otherEntityNamePascalized %> to test the ManyToMany association
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             <%= relationship.otherEntityNameCamelCased %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Add(_<%= camelCasedEntityClass %>);
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
@@ -935,29 +699,7 @@ namespace <%= namespace %>.Test.Controllers {
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             // Create a second <%= relationship.otherEntityNamePascalized %> to update the ManyToMany association
-            var updated<%= relationship.otherEntityNamePascalized %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var updated<%= relationship.otherEntityNamePascalized %> = AssociatedEntityFactories.getUpdatedAssociated<%= relationship.otherEntityNamePascalized %>();
             updated<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Add(updated<%= pascalizedEntityClass %>);
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(updated<%= relationship.otherEntityNamePascalized %>);
             await _applicationDatabaseContext.SaveChangesAsync();
@@ -987,21 +729,8 @@ namespace <%= namespace %>.Test.Controllers {
                     .ThenInclude(<%= relationship.joinEntityNameCamelCased %> => <%= relationship.joinEntityNameCamelCased %>.<%= pascalizedEntityClass %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == updated<%= relationship.otherEntityNamePascalized %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            testUpdated<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(updated<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(testUpdated<%= relationship.otherEntityNamePascalized %>, updated<%= relationship.otherEntityNamePascalized %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             testUpdated<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>[0].Should().Be(test<%= pascalizedEntityClass %>);
 
             // Validate the <%= relationship.otherEntityNameCamelCased %> in the database and in particular there is no more <%= pascalizedEntityClass%> referenced
@@ -1010,21 +739,8 @@ namespace <%= namespace %>.Test.Controllers {
                     .ThenInclude(<%= relationship.joinEntityNameCamelCased %> => <%= relationship.joinEntityNameCamelCased %>.<%= pascalizedEntityClass %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            test<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             <%_ if (relationship.ownerSide) { _%>
             test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Should().BeEmpty();
             <%_ } else { _%>
@@ -1055,32 +771,10 @@ namespace <%= namespace %>.Test.Controllers {
             if (relationship.relationshipType === 'many-to-one' && relationship.otherEntityName.toUpperCase() !== 'USER'
                 && relationship.otherEntityName.toUpperCase() !== 'USERROLE' && relationship.otherEntityName.toUpperCase() !== 'ROLE') { _%>
         [Fact]
-        public async Task Delete<%= pascalizedEntityClass%>WithExistingReferenced<%= relationship.otherEntityNamePascalized %>()
+        public async Task Delete<%= pascalizedEntityClass%>WithExistingReferenced<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>Relationship()
         {
             // Create a <%= relationship.otherEntityNamePascalized %> to referenced
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
 
@@ -1104,24 +798,11 @@ namespace <%= namespace %>.Test.Controllers {
 
             // Validate the <%= relationship.otherEntityNamePascalized %> in the database and in particular there is no more <%= pascalizedEntityClass %> referenced
             var test<%= relationship.otherEntityNamePascalized %> = await _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>
-                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= pascalizedEntityClassPlural %>)
+                .Include(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            test<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Should().BeEmpty();
         }
 
@@ -1130,33 +811,11 @@ namespace <%= namespace %>.Test.Controllers {
         <%_ relationships.forEach(relationship => {
             if (relationship.relationshipType === 'many-to-many') { _%>
         [Fact]
-        public async Task Delete<%= pascalizedEntityClass%>WithManyToManyAssociationWith<%= relationship.otherEntityNamePascalized %>()
+        public async Task Delete<%= pascalizedEntityClass%>WithManyToManyAssociationReferencing<%= relationship.otherEntityNamePascalized %>On<%= relationship.relationshipNamePascalized %>Relationship()
         {
             <%_ if (relationship.ownerSide) { _%>
             // Create a <%= relationship.otherEntityNamePascalized %> to test the ManyToMany association
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
 
@@ -1173,29 +832,7 @@ namespace <%= namespace %>.Test.Controllers {
             await _applicationDatabaseContext.SaveChangesAsync();
 
             // Create an <%= relationship.otherEntityNamePascalized %> to test the ManyToMany association
-            var <%= relationship.otherEntityNameCamelCased %> = new <%= relationship.otherEntityNamePascalized %> {
-                <%_ j = 0;
-                found = false;
-                while (j < entities.length && !found) {
-                    const entity = entities[j];
-                    if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                        let k = 0;
-                        if (entity.definition.fields.length != 0) {
-                            while (k < entity.definition.fields.length - 1) {
-                                const field = entity.definition.fields[k];
-                                const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
-                                <%_ k ++;
-                            }
-                            const field = entity.definition.fields[k];
-                            const fieldType = equivalentCSharpType(field.fieldType); _%>
-                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
-                        <%_ }
-                        found = true;
-                    }
-                    j ++;
-                } _%>
-            };
+            var <%= relationship.otherEntityNameCamelCased %> = AssociatedEntityFactories.getDefaultAssociated<%= relationship.otherEntityNamePascalized %>();
             <%= relationship.otherEntityNameCamelCased %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Add(_<%= camelCasedEntityClass %>);
             _applicationDatabaseContext.<%= relationship.otherEntityNamePascalizedPlural %>.Add(<%= relationship.otherEntityNameCamelCased %>);
             await _applicationDatabaseContext.SaveChangesAsync();
@@ -1218,21 +855,8 @@ namespace <%= namespace %>.Test.Controllers {
                     .ThenInclude(<%= relationship.joinEntityNameCamelCased %> => <%= relationship.joinEntityNameCamelCased %>.<%= pascalizedEntityClass %>)
                 .AsNoTracking()
                 .SingleOrDefaultAsync(<%= (relationship.otherEntityNameCamelCased).charAt(0) %> => <%= (relationship.otherEntityNameCamelCased).charAt(0) %>.Id == <%= relationship.otherEntityNameCamelCased %>.Id);
-            <%_ j = 0;
-            found = false;
-            while (j < entities.length && !found) {
-                const entity = entities[j];
-                if(entity.name.toUpperCase() === relationship.otherEntityName.toUpperCase()) {
-                    let k = 0;
-                    while (k < entity.definition.fields.length) {
-                        const field = entity.definition.fields[k]; _%>
-            test<%= relationship.otherEntityNamePascalized %>.<%= toPascalCase(field.fieldName) %>.Should().Be(<%= relationship.otherEntityNameCamelCased %>.<%= toPascalCase(field.fieldName) %>);
-                        <%_ k ++;
-                    }
-                    found = true;
-                }
-                j ++;
-            } _%>
+            HashSet<string> navProperties = TestUtil.GetNavigationProperties(_applicationDatabaseContext, typeof(<%= relationship.otherEntityNamePascalized %>));
+            TestUtil.CompareObjects(test<%= relationship.otherEntityNamePascalized %>, <%= relationship.otherEntityNameCamelCased %>, navProperties, _applicationDatabaseContext).Should().BeTrue();
             test<%= relationship.otherEntityNamePascalized %>.<%= relationship.otherEntityRelationshipFieldNamePascalizedPlural %>.Should().BeEmpty();
         }
 

--- a/generators/entity-server/templates/dotnetcore/test/Project.Test/Controllers/EntityResourceIntTest.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/test/Project.Test/Controllers/EntityResourceIntTest.cs.ejs
@@ -223,7 +223,7 @@ namespace <%= namespace %>.Test.Controllers {
                     while (i < fields.length - 1) { _%>
                     <%= fields[i].fieldNamePascalized %> = Default<%= fields[i].fieldNamePascalized %>,
                         <%_ i ++;
-                    }; _%>
+                    } _%>
                     <%= fields[i].fieldNamePascalized %> = Default<%= fields[i].fieldNamePascalized %>
                 <%_ }_%>
             };

--- a/generators/entity-server/templates/dotnetcore/test/Project.Test/Setup/AssociatedEntityFactories.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/test/Project.Test/Setup/AssociatedEntityFactories.cs.ejs
@@ -196,7 +196,7 @@ namespace <%= namespace %>.Test.Setup {
         public static <%= entity.name %> getUpdatedAssociated<%= entity.name %>()
         {
             var updated<%= entity.name %> = new <%= entity.name %> {
-                <%_ let i = 0;
+                <%_ i = 0;
                 if (entity.definition.fields.length != 0) {
                     while (i < entity.definition.fields.length - 1) {
                         const field = entity.definition.fields[i];
@@ -236,7 +236,7 @@ namespace <%= namespace %>.Test.Setup {
         public static <%= pascalizedEntityClass %> getUpdatedAssociated<%= pascalizedEntityClass %>()
         {
             var updated<%= pascalizedEntityClass %> = new <%= pascalizedEntityClass %> {
-                <%_ let i = 0;
+                <%_ i = 0;
                 if (fields.length != 0) {
                     while (i < fields.length - 1) {
                         const fieldType = equivalentCSharpType(fields[i].fieldType); _%>

--- a/generators/entity-server/templates/dotnetcore/test/Project.Test/Setup/AssociatedEntityFactories.cs.ejs
+++ b/generators/entity-server/templates/dotnetcore/test/Project.Test/Setup/AssociatedEntityFactories.cs.ejs
@@ -1,0 +1,254 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<%_ function defaultValue(cSharpType) {
+    let defaultValue;
+    const defaultNumValue = 1;
+
+    switch (cSharpType) {
+        case 'string' :
+            defaultValue = "\"AAAAAAAAAA\"";
+            break;
+        case 'int?' :
+            defaultValue = `${defaultNumValue}`;
+            break;
+        case 'long?' :
+            defaultValue = `${defaultNumValue}L`;
+            break;
+        case 'float?' :
+            defaultValue = `${defaultNumValue}F`;
+            break;
+        case 'double?' :
+            defaultValue = `${defaultNumValue}D`;
+            break;
+        case 'decimal?' :
+            defaultValue = `${defaultNumValue}M`;
+            break;
+        case 'DateTime?' :
+            defaultValue = "DateTime.UnixEpoch";
+            break;
+        case 'bool?' :
+            defaultValue = "false";
+            break;
+    }
+
+    return defaultValue;
+}
+function updatedValue(cSharpType) {
+    let updatedValue;
+    const updatedNumValue = 2;
+
+    switch (cSharpType) {
+        case 'string' :
+            updatedValue = "\"BBBBBBBBBB\"";
+            break;
+        case 'int?' :
+            updatedValue = `${updatedNumValue}`;
+            break;
+        case 'long?' :
+            updatedValue = `${updatedNumValue}L`;
+            break;
+        case 'float?' :
+            updatedValue = `${updatedNumValue}F`;
+            break;
+        case 'double?' :
+            updatedValue = `${updatedNumValue}D`;
+            break;
+        case 'decimal?' :
+            updatedValue = `${updatedNumValue}M`;
+            break;
+        case 'DateTime?' :
+            updatedValue = "DateTime.Now";
+            break;
+        case 'bool?' :
+            updatedValue = "true";
+            break;
+    }
+
+    return updatedValue;
+}
+function equivalentCSharpType(javaType) {
+    let cSharpType;
+
+    switch(javaType) {
+        case 'String':
+            cSharpType = 'string';
+            break;
+        case 'Integer':
+            cSharpType = 'int?';
+            break;
+        case 'Long':
+            cSharpType = 'long?';
+            break;
+        case 'Float':
+            cSharpType = 'float?';
+            break;
+        case 'Double':
+            cSharpType = 'double?';
+            break;
+        case 'BigDecimal':
+            cSharpType = 'decimal?';
+            break;
+        case 'LocalDate':
+            cSharpType = 'DateTime?';
+            break;
+        case 'Instant':
+            cSharpType = 'LOOK_FOR_AN_EQUIVALENT';
+            break;
+        case 'ZonedDateTime':
+            cSharpType = 'LOOK_FOR_AN_EQUIVALENT';
+            break;
+        case 'Duration':
+            cSharpType = 'LOOK_FOR_AN_EQUIVALENT';
+            break;
+        case 'Boolean':
+            cSharpType = 'bool?';
+            break;
+        case 'Enumeration':
+            cSharpType = 'LOOK_FOR_AN_EQUIVALENT';
+            break;
+        case 'Blob':
+            cSharpType = 'LOOK_FOR_AN_EQUIVALENT';
+            break;
+        default:
+            cSharpType = 'UNKNOWN_TYPE';
+    }
+
+    return cSharpType;
+}
+function entitiesHaveDateTimeTypeField() {
+    let dateTimeTypeFieldActualEntity = false;
+    let dateTimeTypeFieldOtherEntities = false;
+    let dateTimeTypeField = false;
+
+    let idx = 0;
+    while (idx < fields.length && !dateTimeTypeFieldActualEntity) {
+        if (fields[idx].fieldType === 'LocalDate') {
+            dateTimeTypeFieldActualEntity = true;
+        }
+        idx ++;
+    }
+
+    idx = 0;
+    while (idx < entities.length && !dateTimeTypeFieldOtherEntities) {
+        const entity = entities[idx];
+
+        let j = 0;
+        while (j < entity.definition.fields.length && !dateTimeTypeFieldOtherEntities) {
+            if (entity.definition.fields[j].fieldType === 'LocalDate') {
+                dateTimeTypeFieldOtherEntities = true;
+            }
+            j++;
+        }
+        idx ++;
+    }
+
+    if (dateTimeTypeFieldActualEntity || dateTimeTypeFieldOtherEntities) {
+        dateTimeTypeField = true;
+    }
+
+    return dateTimeTypeField;
+} _%>
+using <%= namespace %>.Models;
+<%_ if (entitiesHaveDateTimeTypeField()) { _%>
+using System;
+<%_ } _%>
+
+namespace <%= namespace %>.Test.Setup {
+    public class AssociatedEntityFactories {
+        <%_ entities.forEach(entity => {
+            if(entity.name.toUpperCase() !== entityClass.toUpperCase()) { _%>
+        public static <%= entity.name %> getDefaultAssociated<%= entity.name %>()
+        {
+            var <%= _.camelCase(entity.name) %> = new <%= entity.name %> {
+                <%_ let i = 0;
+                if (entity.definition.fields.length != 0) {
+                    while (i < entity.definition.fields.length - 1) {
+                        const field = entity.definition.fields[i];
+                        const fieldType = equivalentCSharpType(field.fieldType); _%>
+                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>,
+                        <%_ i ++;
+                    }
+                    const field = entity.definition.fields[i];
+                    const fieldType = equivalentCSharpType(field.fieldType); _%>
+                <%= toPascalCase(field.fieldName) %> = <%- defaultValue(fieldType) %>
+                <%_ } _%>
+            };
+
+            return <%= _.camelCase(entity.name) %>;
+        }
+
+        public static <%= entity.name %> getUpdatedAssociated<%= entity.name %>()
+        {
+            var updated<%= entity.name %> = new <%= entity.name %> {
+                <%_ let i = 0;
+                if (entity.definition.fields.length != 0) {
+                    while (i < entity.definition.fields.length - 1) {
+                        const field = entity.definition.fields[i];
+                        const fieldType = equivalentCSharpType(field.fieldType); _%>
+                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>,
+                        <%_ i ++;
+                    }
+                    const field = entity.definition.fields[i];
+                    const fieldType = equivalentCSharpType(field.fieldType); _%>
+                <%= toPascalCase(field.fieldName) %> = <%- updatedValue(fieldType) %>
+                <%_ } _%>
+            };
+
+            return updated<%= entity.name %>;
+        }
+
+            <%_ }
+        }); _%>
+        public static <%= pascalizedEntityClass %> getDefaultAssociated<%= pascalizedEntityClass %>()
+        {
+            var <%= camelCasedEntityClass %> = new <%= pascalizedEntityClass %> {
+                <%_ let i = 0;
+                if (fields.length != 0) {
+                    while (i < fields.length - 1) {
+                        const fieldType = equivalentCSharpType(fields[i].fieldType); _%>
+                <%= fields[i].fieldNamePascalized %> = <%- defaultValue(fieldType) %>,
+                        <%_ i ++;
+                    }
+                    const fieldType = equivalentCSharpType(fields[i].fieldType); _%>
+                <%= fields[i].fieldNamePascalized %> = <%- defaultValue(fieldType) %>
+                <%_ }_%>
+            };
+
+            return <%= camelCasedEntityClass %>;
+        }
+
+        public static <%= pascalizedEntityClass %> getUpdatedAssociated<%= pascalizedEntityClass %>()
+        {
+            var updated<%= pascalizedEntityClass %> = new <%= pascalizedEntityClass %> {
+                <%_ let i = 0;
+                if (fields.length != 0) {
+                    while (i < fields.length - 1) {
+                        const fieldType = equivalentCSharpType(fields[i].fieldType); _%>
+                <%= fields[i].fieldNamePascalized %> = <%- updatedValue(fieldType) %>,
+                        <%_ i ++;
+                    }
+                    const fieldType = equivalentCSharpType(fields[i].fieldType); _%>
+                <%= fields[i].fieldNamePascalized %> = <%- updatedValue(fieldType) %>
+                <%_ }_%>
+            };
+
+            return updated<%= pascalizedEntityClass %>;
+        }
+    }
+}

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -1,0 +1,1139 @@
+/**
+ * Copyright 2013-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const chalk = require('chalk');
+const path = require('path');
+const _ = require('lodash');
+const jhiCore = require('jhipster-core');
+const shelljs = require('shelljs');
+
+module.exports = {
+    askForMicroserviceJson,
+    askForUpdate,
+    askForFields,
+    askForFieldsToRemove,
+    askForRelationships,
+    askForRelationsToRemove,
+    askForTableName,
+    askForDTO,
+    askForService,
+    askForFiltering,
+    askForPagination
+};
+
+function askForMicroserviceJson() {
+    const context = this.context;
+    if (context.applicationType !== 'gateway' || context.useConfigurationFile) {
+        return;
+    }
+
+    const done = this.async();
+    const databaseType = context.databaseType;
+
+    const prompts = [
+        {
+            when: () => databaseType !== 'no',
+            type: 'confirm',
+            name: 'useMicroserviceJson',
+            message: 'Do you want to generate this entity from an existing microservice?',
+            default: true
+        },
+        {
+            when: response => response.useMicroserviceJson === true || databaseType === 'no',
+            type: 'input',
+            name: 'microservicePath',
+            message: 'Enter the path to the microservice root directory:',
+            store: true,
+            validate: input => {
+                let fromPath;
+                if (path.isAbsolute(input)) {
+                    fromPath = `${input}/${context.filename}`;
+                } else {
+                    fromPath = this.destinationPath(`${input}/${context.filename}`);
+                }
+
+                if (shelljs.test('-f', fromPath)) {
+                    return true;
+                }
+                return `${context.filename} not found in ${input}/`;
+            }
+        }
+    ];
+
+    this.prompt(prompts).then(props => {
+        if (props.microservicePath) {
+            this.log(chalk.green(`\nFound the ${context.filename} configuration file, entity can be automatically generated!\n`));
+            if (path.isAbsolute(props.microservicePath)) {
+                context.microservicePath = props.microservicePath;
+            } else {
+                context.microservicePath = path.resolve(props.microservicePath);
+            }
+            context.useConfigurationFile = true;
+            context.useMicroserviceJson = true;
+            const fromPath = `${context.microservicePath}/${context.jhipsterConfigDirectory}/${context.entityNameCapitalized}.json`;
+            this.loadEntityJson(fromPath);
+        }
+        done();
+    });
+}
+
+function askForUpdate() {
+    const context = this.context;
+    // ask only if running an existing entity without arg option --force or --regenerate
+    const isForce = context.options.force || context.regenerate;
+    context.updateEntity = 'regenerate'; // default if skipping questions by --force
+    if (isForce || !context.useConfigurationFile) {
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'list',
+            name: 'updateEntity',
+            message:
+                'Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwritten',
+            choices: [
+                {
+                    value: 'regenerate',
+                    name: 'Yes, re generate the entity'
+                },
+                {
+                    value: 'add',
+                    name: 'Yes, add more fields and relationships'
+                },
+                {
+                    value: 'remove',
+                    name: 'Yes, remove fields and relationships'
+                },
+                {
+                    value: 'none',
+                    name: 'No, exit'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        context.updateEntity = props.updateEntity;
+        if (context.updateEntity === 'none') {
+            this.env.error(chalk.green('Aborting entity update, no changes were made.'));
+        }
+        done();
+    });
+}
+
+function askForFields() {
+    const context = this.context;
+    // don't prompt if data is imported from a file
+    if (context.useConfigurationFile && context.updateEntity !== 'add') {
+        return;
+    }
+
+    if (context.updateEntity === 'add') {
+        logFieldsAndRelationships.call(this);
+    }
+
+    const done = this.async();
+
+    askForField.call(this, done);
+}
+
+function askForFieldsToRemove() {
+    const context = this.context;
+    // prompt only if data is imported from a file
+    if (!context.useConfigurationFile || context.updateEntity !== 'remove' || context.fieldNameChoices.length === 0) {
+        return;
+    }
+    const done = this.async();
+
+    const prompts = [
+        {
+            type: 'checkbox',
+            name: 'fieldsToRemove',
+            message: 'Please choose the fields you want to remove',
+            choices: context.fieldNameChoices
+        },
+        {
+            when: response => response.fieldsToRemove.length !== 0,
+            type: 'confirm',
+            name: 'confirmRemove',
+            message: 'Are you sure to remove these fields?',
+            default: true
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        if (props.confirmRemove) {
+            this.log(chalk.red(`\nRemoving fields: ${props.fieldsToRemove}\n`));
+            for (let i = context.fields.length - 1; i >= 0; i -= 1) {
+                const field = context.fields[i];
+                if (props.fieldsToRemove.filter(val => val === field.fieldName).length > 0) {
+                    context.fields.splice(i, 1);
+                }
+            }
+        }
+        done();
+    });
+}
+
+function askForRelationships() {
+    const context = this.context;
+    // don't prompt if data is imported from a file
+    if (context.useConfigurationFile && context.updateEntity !== 'add') {
+        return;
+    }
+    if (context.databaseType === 'cassandra') {
+        return;
+    }
+
+    const done = this.async();
+
+    askForRelationship.call(this, done);
+}
+
+function askForRelationsToRemove() {
+    const context = this.context;
+    // prompt only if data is imported from a file
+    if (!context.useConfigurationFile || context.updateEntity !== 'remove' || context.relNameChoices.length === 0) {
+        return;
+    }
+    if (context.databaseType === 'cassandra') {
+        return;
+    }
+
+    const done = this.async();
+
+    const prompts = [
+        {
+            type: 'checkbox',
+            name: 'relsToRemove',
+            message: 'Please choose the relationships you want to remove',
+            choices: context.relNameChoices
+        },
+        {
+            when: response => response.relsToRemove.length !== 0,
+            type: 'confirm',
+            name: 'confirmRemove',
+            message: 'Are you sure to remove these relationships?',
+            default: true
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        if (props.confirmRemove) {
+            this.log(chalk.red(`\nRemoving relationships: ${props.relsToRemove}\n`));
+            for (let i = context.relationships.length - 1; i >= 0; i -= 1) {
+                const rel = context.relationships[i];
+                if (props.relsToRemove.filter(val => val === `${rel.relationshipName}:${rel.relationshipType}`).length > 0) {
+                    context.relationships.splice(i, 1);
+                }
+            }
+        }
+        done();
+    });
+}
+
+function askForTableName() {
+    const context = this.context;
+    // don't prompt if there are no relationships
+    const entityTableName = context.entityTableName;
+    const prodDatabaseType = context.prodDatabaseType;
+    const skipCheckLengthOfIdentifier = context.skipCheckLengthOfIdentifier;
+    if (
+        skipCheckLengthOfIdentifier ||
+        !context.relationships ||
+        context.relationships.length === 0 ||
+        !((prodDatabaseType === 'oracle' && entityTableName.length > 14) || entityTableName.length > 30)
+    ) {
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'input',
+            name: 'entityTableName',
+            message: 'The table name for this entity is too long to form constraint names. Please use a shorter table name',
+            validate: input => {
+                if (!/^([a-zA-Z0-9_]*)$/.test(input)) {
+                    return 'The table name cannot contain special characters';
+                }
+                if (input === '') {
+                    return 'The table name cannot be empty';
+                }
+                if (prodDatabaseType === 'oracle' && input.length > 14 && !skipCheckLengthOfIdentifier) {
+                    return 'The table name is too long for Oracle, try a shorter name';
+                }
+                if (input.length > 30 && !skipCheckLengthOfIdentifier) {
+                    return 'The table name is too long, try a shorter name';
+                }
+                return true;
+            },
+            default: entityTableName
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        /* overwrite the table name for the entity using name obtained from the user */
+        if (props.entityTableName !== context.entityTableName) {
+            context.entityTableName = _.snakeCase(props.entityTableName).toLowerCase();
+        }
+        done();
+    });
+}
+
+function askForFiltering() {
+    const context = this.context;
+    // don't prompt if server is skipped, or the backend is not sql, or no service requested
+    if (context.useConfigurationFile || context.skipServer || context.databaseType !== 'sql' || context.service === 'no') {
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'list',
+            name: 'filtering',
+            message: 'Do you want to add filtering?',
+            choices: [
+                {
+                    value: 'no',
+                    name: 'Not needed'
+                },
+                {
+                    name: 'Dynamic filtering for the entities with JPA Static metamodel',
+                    value: 'jpaMetamodel'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        context.jpaMetamodelFiltering = props.filtering === 'jpaMetamodel';
+        done();
+    });
+}
+
+function askForDTO() {
+    const context = this.context;
+    // don't prompt if data is imported from a file or server is skipped or if no service layer
+    if (context.useConfigurationFile || context.skipServer || context.service === 'no') {
+        context.dto = context.dto || 'no';
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'list',
+            name: 'dto',
+            message: 'Do you want to use a Data Transfer Object (DTO)?',
+            choices: [
+                {
+                    value: 'no',
+                    name: 'No, use the entity directly'
+                },
+                {
+                    value: 'mapstruct',
+                    name: 'Yes, generate a DTO with MapStruct'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        context.dto = props.dto;
+        done();
+    });
+}
+
+function askForService() {
+    const context = this.context;
+    // don't prompt if data is imported from a file or server is skipped
+    if (context.useConfigurationFile || context.skipServer) {
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'list',
+            name: 'service',
+            message: 'Do you want to use separate service class for your business logic?',
+            choices: [
+                {
+                    value: 'no',
+                    name: 'No, the REST controller should use the repository directly'
+                },
+                {
+                    value: 'serviceClass',
+                    name: 'Yes, generate a separate service class'
+                },
+                {
+                    value: 'serviceImpl',
+                    name: 'Yes, generate a separate service interface and implementation'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        context.service = props.service;
+        done();
+    });
+}
+
+function askForPagination() {
+    const context = this.context;
+    // don't prompt if data are imported from a file
+    if (context.useConfigurationFile) {
+        return;
+    }
+    if (context.databaseType === 'cassandra') {
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'list',
+            name: 'pagination',
+            message: 'Do you want pagination on your entity?',
+            choices: [
+                {
+                    value: 'no',
+                    name: 'No'
+                },
+                {
+                    value: 'pagination',
+                    name: 'Yes, with pagination links'
+                },
+                {
+                    value: 'infinite-scroll',
+                    name: 'Yes, with infinite scroll'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        context.pagination = props.pagination;
+        this.log(chalk.green('\nEverything is configured, generating the entity...\n'));
+        done();
+    });
+}
+
+/**
+ * ask question for a field creation
+ */
+function askForField(done) {
+    const context = this.context;
+    this.log(chalk.green(`\nGenerating field #${context.fields.length + 1}\n`));
+    const skipServer = context.skipServer;
+    const prodDatabaseType = context.prodDatabaseType;
+    const databaseType = context.databaseType;
+    const clientFramework = context.clientFramework;
+    const fieldNamesUnderscored = context.fieldNamesUnderscored;
+    const skipCheckLengthOfIdentifier = context.skipCheckLengthOfIdentifier;
+    const prompts = [
+        {
+            type: 'confirm',
+            name: 'fieldAdd',
+            message: 'Do you want to add a field to your entity?',
+            default: true
+        },
+        {
+            when: response => response.fieldAdd === true,
+            type: 'input',
+            name: 'fieldName',
+            validate: input => {
+                if (!/^([a-zA-Z0-9_]*)$/.test(input)) {
+                    return 'Your field name cannot contain special characters';
+                }
+                if (input === '') {
+                    return 'Your field name cannot be empty';
+                }
+                if (input.charAt(0) === input.charAt(0).toUpperCase()) {
+                    return 'Your field name cannot start with an upper case letter';
+                }
+                if (input === 'id' || fieldNamesUnderscored.includes(_.snakeCase(input))) {
+                    return 'Your field name cannot use an already existing field name';
+                }
+                if ((clientFramework === undefined || clientFramework === 'angularX') && jhiCore.isReservedFieldName(input, 'angularX')) {
+                    return 'Your field name cannot contain a Java or Angular reserved keyword';
+                }
+                if ((clientFramework !== undefined || clientFramework === 'react') && jhiCore.isReservedFieldName(input, 'react')) {
+                    return 'Your field name cannot contain a Java or React reserved keyword';
+                }
+                if (prodDatabaseType === 'oracle' && input.length > 30 && !skipCheckLengthOfIdentifier) {
+                    return 'The field name cannot be of more than 30 characters';
+                }
+                return true;
+            },
+            message: 'What is the name of your field?'
+        },
+        {
+            when: response => response.fieldAdd === true && (skipServer || ['sql', 'mongodb', 'couchbase'].includes(databaseType)),
+            type: 'list',
+            name: 'fieldType',
+            message: 'What is the type of your field?',
+            choices: [
+                {
+                    value: 'String',
+                    name: 'String'
+                },
+                {
+                    value: 'Integer',
+                    name: 'Integer'
+                },
+                {
+                    value: 'Long',
+                    name: 'Long'
+                },
+                {
+                    value: 'Float',
+                    name: 'Float'
+                },
+                {
+                    value: 'Double',
+                    name: 'Double'
+                },
+                {
+                    value: 'BigDecimal',
+                    name: 'BigDecimal'
+                },
+                {
+                    value: 'LocalDate',
+                    name: 'LocalDate'
+                },
+                {
+                    value: 'Instant',
+                    name: 'Instant'
+                },
+                {
+                    value: 'ZonedDateTime',
+                    name: 'ZonedDateTime'
+                },
+                {
+                    value: 'Duration',
+                    name: 'Duration'
+                },
+                {
+                    value: 'Boolean',
+                    name: 'Boolean'
+                },
+                {
+                    value: 'enum',
+                    name: 'Enumeration (Java enum type)'
+                },
+                {
+                    value: 'byte[]',
+                    name: '[BETA] Blob'
+                }
+            ],
+            default: 0
+        },
+        {
+            when: response => {
+                if (response.fieldType === 'enum') {
+                    response.fieldIsEnum = true;
+                    return true;
+                }
+                response.fieldIsEnum = false;
+                return false;
+            },
+            type: 'input',
+            name: 'fieldType',
+            validate: input => {
+                if (input === '') {
+                    return 'Your class name cannot be empty.';
+                }
+                if (jhiCore.isReservedKeyword(input, 'JAVA')) {
+                    return 'Your enum name cannot contain a Java reserved keyword';
+                }
+                if (!/^[A-Za-z0-9_]*$/.test(input)) {
+                    return 'Your enum name cannot contain special characters (allowed characters: A-Z, a-z, 0-9 and _)';
+                }
+                if (context.enums.includes(input)) {
+                    context.existingEnum = true;
+                } else {
+                    context.enums.push(input);
+                }
+                return true;
+            },
+            message: 'What is the class name of your enumeration?'
+        },
+        {
+            when: response => response.fieldIsEnum,
+            type: 'input',
+            name: 'fieldValues',
+            validate: input => {
+                if (input === '' && context.existingEnum) {
+                    context.existingEnum = false;
+                    return true;
+                }
+                if (input === '') {
+                    return 'You must specify values for your enumeration';
+                }
+                // Commas allowed so that user can input a list of values split by commas.
+                if (!/^[A-Za-z0-9_,]+$/.test(input)) {
+                    return 'Enum values cannot contain special characters (allowed characters: A-Z, a-z, 0-9 and _)';
+                }
+                const enums = input.replace(/\s/g, '').split(',');
+                if (_.uniq(enums).length !== enums.length) {
+                    return `Enum values cannot contain duplicates (typed values: ${input})`;
+                }
+                for (let i = 0; i < enums.length; i++) {
+                    if (/^[0-9].*/.test(enums[i])) {
+                        return `Enum value "${enums[i]}" cannot start with a number`;
+                    }
+                    if (enums[i] === '') {
+                        return 'Enum value cannot be empty (did you accidentally type "," twice in a row?)';
+                    }
+                }
+
+                return true;
+            },
+            message: answers => {
+                if (!context.existingEnum) {
+                    return 'What are the values of your enumeration (separated by comma, no spaces)?';
+                }
+                return 'What are the new values of your enumeration (separated by comma, no spaces)?\nThe new values will replace the old ones.\nNothing will be done if there are no new values.';
+            }
+        },
+        {
+            when: response => response.fieldAdd === true && databaseType === 'cassandra',
+            type: 'list',
+            name: 'fieldType',
+            message: 'What is the type of your field?',
+            choices: [
+                {
+                    value: 'UUID',
+                    name: 'UUID'
+                },
+                {
+                    value: 'String',
+                    name: 'String'
+                },
+                {
+                    value: 'Integer',
+                    name: 'Integer'
+                },
+                {
+                    value: 'Long',
+                    name: 'Long'
+                },
+                {
+                    value: 'Float',
+                    name: 'Float'
+                },
+                {
+                    value: 'Double',
+                    name: 'Double'
+                },
+                {
+                    value: 'BigDecimal',
+                    name: 'BigDecimal'
+                },
+                {
+                    value: 'LocalDate',
+                    name: 'LocalDate (Warning: only compatible with Cassandra v3)'
+                },
+                {
+                    value: 'Instant',
+                    name: 'Instant'
+                },
+                {
+                    value: 'ZonedDateTime',
+                    name: 'ZonedDateTime'
+                },
+                {
+                    value: 'Boolean',
+                    name: 'Boolean'
+                },
+                {
+                    value: 'ByteBuffer',
+                    name: '[BETA] blob'
+                }
+            ],
+            default: 0
+        },
+        {
+            when: response => response.fieldAdd === true && response.fieldType === 'byte[]',
+            type: 'list',
+            name: 'fieldTypeBlobContent',
+            message: 'What is the content of the Blob field?',
+            choices: [
+                {
+                    value: 'image',
+                    name: 'An image'
+                },
+                {
+                    value: 'any',
+                    name: 'A binary file'
+                },
+                {
+                    value: 'text',
+                    name: 'A CLOB (Text field)'
+                }
+            ],
+            default: 0
+        },
+        {
+            when: response => response.fieldAdd === true && response.fieldType === 'ByteBuffer',
+            type: 'list',
+            name: 'fieldTypeBlobContent',
+            message: 'What is the content of the Blob field?',
+            choices: [
+                {
+                    value: 'image',
+                    name: 'An image'
+                },
+                {
+                    value: 'any',
+                    name: 'A binary file'
+                }
+            ],
+            default: 0
+        },
+        {
+            when: response => response.fieldAdd === true && response.fieldType !== 'ByteBuffer',
+            type: 'confirm',
+            name: 'fieldValidate',
+            message: 'Do you want to add validation rules to your field?',
+            default: false
+        },
+        {
+            when: response => response.fieldAdd === true && response.fieldValidate === true,
+            type: 'checkbox',
+            name: 'fieldValidateRules',
+            message: 'Which validation rules do you want to add?',
+            choices: response => {
+                // Default rules applicable for fieldType 'LocalDate', 'Instant',
+                // 'ZonedDateTime', 'Duration', 'UUID', 'Boolean', 'ByteBuffer' and 'Enum'
+                const opts = [
+                    {
+                        name: 'Required',
+                        value: 'required'
+                    },
+                    {
+                        name: 'Unique',
+                        value: 'unique'
+                    }
+                ];
+                if (response.fieldType === 'String' || response.fieldTypeBlobContent === 'text') {
+                    opts.push(
+                        {
+                            name: 'Minimum length',
+                            value: 'minlength'
+                        },
+                        {
+                            name: 'Maximum length',
+                            value: 'maxlength'
+                        },
+                        {
+                            name: 'Regular expression pattern',
+                            value: 'pattern'
+                        }
+                    );
+                } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(response.fieldType)) {
+                    opts.push(
+                        {
+                            name: 'Minimum',
+                            value: 'min'
+                        },
+                        {
+                            name: 'Maximum',
+                            value: 'max'
+                        }
+                    );
+                }
+                return opts;
+            },
+            default: 0
+        },
+        {
+            when: response =>
+                response.fieldAdd === true && response.fieldValidate === true && response.fieldValidateRules.includes('minlength'),
+            type: 'input',
+            name: 'fieldValidateRulesMinlength',
+            validate: input => (this.isNumber(input) ? true : 'Minimum length must be a positive number'),
+            message: 'What is the minimum length of your field?',
+            default: 0
+        },
+        {
+            when: response =>
+                response.fieldAdd === true && response.fieldValidate === true && response.fieldValidateRules.includes('maxlength'),
+            type: 'input',
+            name: 'fieldValidateRulesMaxlength',
+            validate: input => (this.isNumber(input) ? true : 'Maximum length must be a positive number'),
+            message: 'What is the maximum length of your field?',
+            default: 20
+        },
+        {
+            when: response => response.fieldAdd === true && response.fieldValidate === true && response.fieldValidateRules.includes('min'),
+            type: 'input',
+            name: 'fieldValidateRulesMin',
+            message: 'What is the minimum of your field?',
+            validate: (input, response) => {
+                if (['Float', 'Double', 'BigDecimal'].includes(response.fieldType)) {
+                    return this.isSignedDecimalNumber(input) ? true : 'Minimum must be a decimal number';
+                }
+                return this.isSignedNumber(input) ? true : 'Minimum must be a number';
+            },
+            default: 0
+        },
+        {
+            when: response => response.fieldAdd === true && response.fieldValidate === true && response.fieldValidateRules.includes('max'),
+            type: 'input',
+            name: 'fieldValidateRulesMax',
+            message: 'What is the maximum of your field?',
+            validate: (input, response) => {
+                if (['Float', 'Double', 'BigDecimal'].includes(response.fieldType)) {
+                    return this.isSignedDecimalNumber(input) ? true : 'Maximum must be a decimal number';
+                }
+                return this.isSignedNumber(input) ? true : 'Maximum must be a number';
+            },
+            default: 100
+        },
+        {
+            when: response =>
+                response.fieldAdd === true &&
+                response.fieldValidate === true &&
+                response.fieldValidateRules.includes('minbytes') &&
+                response.fieldType === 'byte[]' &&
+                response.fieldTypeBlobContent !== 'text',
+            type: 'input',
+            name: 'fieldValidateRulesMinbytes',
+            message: 'What is the minimum byte size of your field?',
+            validate: input => (this.isNumber(input) ? true : 'Minimum byte size must be a positive number'),
+            default: 0
+        },
+        {
+            when: response =>
+                response.fieldAdd === true &&
+                response.fieldValidate === true &&
+                response.fieldValidateRules.includes('maxbytes') &&
+                response.fieldType === 'byte[]' &&
+                response.fieldTypeBlobContent !== 'text',
+            type: 'input',
+            name: 'fieldValidateRulesMaxbytes',
+            message: 'What is the maximum byte size of your field?',
+            validate: input => (this.isNumber(input) ? true : 'Maximum byte size must be a positive number'),
+            default: 5000000
+        },
+        {
+            when: response =>
+                response.fieldAdd === true && response.fieldValidate === true && response.fieldValidateRules.includes('pattern'),
+            type: 'input',
+            name: 'fieldValidateRulesPattern',
+            message: 'What is the regular expression pattern you want to apply on your field?',
+            default: '^[a-zA-Z0-9]*$'
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        if (props.fieldAdd) {
+            if (props.fieldIsEnum) {
+                props.fieldType = _.upperFirst(props.fieldType);
+                props.fieldValues = props.fieldValues.toUpperCase();
+            }
+
+            const field = {
+                fieldName: props.fieldName,
+                fieldType: props.fieldType,
+                fieldTypeBlobContent: props.fieldTypeBlobContent,
+                fieldValues: props.fieldValues,
+                fieldValidateRules: props.fieldValidateRules,
+                fieldValidateRulesMinlength: props.fieldValidateRulesMinlength,
+                fieldValidateRulesMaxlength: props.fieldValidateRulesMaxlength,
+                fieldValidateRulesPattern: props.fieldValidateRulesPattern,
+                fieldValidateRulesMin: props.fieldValidateRulesMin,
+                fieldValidateRulesMax: props.fieldValidateRulesMax,
+                fieldValidateRulesMinbytes: props.fieldValidateRulesMinbytes,
+                fieldValidateRulesMaxbytes: props.fieldValidateRulesMaxbytes
+            };
+
+            fieldNamesUnderscored.push(_.snakeCase(props.fieldName));
+            context.fields.push(field);
+        }
+        logFieldsAndRelationships.call(this);
+        if (props.fieldAdd) {
+            askForField.call(this, done);
+        } else {
+            done();
+        }
+    });
+}
+
+/**
+ * ask question for a relationship creation
+ */
+function askForRelationship(done) {
+    const context = this.context;
+    const name = context.name;
+    this.log(chalk.green('\nGenerating relationships to other entities\n'));
+    const fieldNamesUnderscored = context.fieldNamesUnderscored;
+    const prompts = [
+        {
+            type: 'confirm',
+            name: 'relationshipAdd',
+            message: 'Do you want to add a relationship to another entity?',
+            default: true
+        },
+        {
+            when: response => response.relationshipAdd === true,
+            type: 'input',
+            name: 'otherEntityName',
+            validate: input => {
+                if (!/^([a-zA-Z0-9_]*)$/.test(input)) {
+                    return 'Your other entity name cannot contain special characters';
+                }
+                if (input === '') {
+                    return 'Your other entity name cannot be empty';
+                }
+                if (jhiCore.isReservedKeyword(input, 'JAVA')) {
+                    return 'Your other entity name cannot contain a Java reserved keyword';
+                }
+                if (input.toLowerCase() === 'user' && context.applicationType === 'microservice') {
+                    return "Your entity cannot have a relationship with User because it's a gateway entity";
+                }
+                return true;
+            },
+            message: 'What is the name of the other entity?'
+        },
+        {
+            when: response => response.relationshipAdd === true,
+            type: 'input',
+            name: 'relationshipName',
+            validate: input => {
+                if (!/^([a-zA-Z0-9_]*)$/.test(input)) {
+                    return 'Your relationship cannot contain special characters';
+                }
+                if (input === '') {
+                    return 'Your relationship cannot be empty';
+                }
+                if (input.charAt(0) === input.charAt(0).toUpperCase()) {
+                    return 'Your relationship cannot start with an upper case letter';
+                }
+                if (input === 'id' || fieldNamesUnderscored.includes(_.snakeCase(input))) {
+                    return 'Your relationship cannot use an already existing field name';
+                }
+                if (jhiCore.isReservedKeyword(input, 'JAVA')) {
+                    return 'Your relationship cannot contain a Java reserved keyword';
+                }
+                return true;
+            },
+            message: 'What is the name of the relationship?',
+            default: response => _.lowerFirst(response.otherEntityName)
+        },
+        {
+            when: response => response.relationshipAdd === true,
+            type: 'list',
+            name: 'relationshipType',
+            message: 'What is the type of the relationship?',
+            choices: response => {
+                const opts = [
+                    {
+                        value: 'many-to-one',
+                        name: 'many-to-one'
+                    },
+                    {
+                        value: 'many-to-many',
+                        name: 'many-to-many'
+                    },
+                    {
+                        value: 'one-to-one',
+                        name: 'one-to-one'
+                    }
+                ];
+                if (response.otherEntityName.toLowerCase() !== 'user') {
+                    opts.unshift({
+                        value: 'one-to-many',
+                        name: 'one-to-many'
+                    });
+                }
+                return opts;
+            },
+            default: 0
+        },
+        {
+            when: response =>
+                response.relationshipAdd === true &&
+                response.otherEntityName.toLowerCase() !== 'user' &&
+                (response.relationshipType === 'many-to-many' || response.relationshipType === 'one-to-one'),
+            type: 'confirm',
+            name: 'ownerSide',
+            message: 'Is this entity the owner of the relationship?',
+            default: false
+        },
+        {
+            when: response =>
+                context.databaseType === 'sql' &&
+                response.relationshipAdd === true &&
+                response.relationshipType === 'one-to-one' &&
+                (response.ownerSide === true || response.otherEntityName.toLowerCase() === 'user'),
+            type: 'confirm',
+            name: 'useJPADerivedIdentifier',
+            message: 'Do you want to use JPA Derived Identifier - @MapsId?',
+            default: false
+        },
+        {
+            when: response =>
+                response.relationshipAdd === true &&
+                (response.relationshipType === 'one-to-many' ||
+                    ((response.relationshipType === 'many-to-many' ||
+                        response.relationshipType === 'one-to-one' ||
+                        response.relationshipType === 'many-to-one') &&
+                        response.otherEntityName.toLowerCase() !== 'user')),
+            type: 'input',
+            name: 'otherEntityRelationshipName',
+            message: 'What is the name of this relationship in the other entity?',
+            default: response => _.lowerFirst(name)
+        },
+        {
+            when: response =>
+                response.relationshipAdd === true &&
+                (response.relationshipType === 'many-to-one' ||
+                    (response.relationshipType === 'many-to-many' && response.ownerSide === true) ||
+                    (response.relationshipType === 'one-to-one' && response.ownerSide === true)),
+            type: 'input',
+            name: 'otherEntityField',
+            message: response =>
+                `When you display this relationship on client-side, which field from '${
+                    response.otherEntityName
+                }' do you want to use? This field will be displayed as a String, so it cannot be a Blob`,
+            default: 'id'
+        },
+        {
+            when: response =>
+                response.relationshipAdd === true &&
+                response.otherEntityName.toLowerCase() !== context.name.toLowerCase() &&
+                (response.relationshipType === 'many-to-one' ||
+                    (response.relationshipType === 'many-to-many' &&
+                        (response.ownerSide === true || response.otherEntityName.toLowerCase() === 'user')) ||
+                    (response.relationshipType === 'one-to-one' &&
+                        (response.ownerSide === true || response.otherEntityName.toLowerCase() === 'user'))),
+            type: 'confirm',
+            name: 'relationshipValidate',
+            message: 'Do you want to add any validation rules to this relationship?',
+            default: false
+        },
+        {
+            when: response => response.relationshipValidate === true,
+            type: 'checkbox',
+            name: 'relationshipValidateRules',
+            message: 'Which validation rules do you want to add?',
+            choices: [
+                {
+                    name: 'Required',
+                    value: 'required'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        if (props.relationshipAdd) {
+            const relationship = {
+                relationshipName: props.relationshipName,
+                otherEntityName: _.lowerFirst(props.otherEntityName),
+                relationshipType: props.relationshipType,
+                relationshipValidateRules: props.relationshipValidateRules,
+                otherEntityField: props.otherEntityField,
+                ownerSide: props.ownerSide,
+                useJPADerivedIdentifier: props.useJPADerivedIdentifier,
+                otherEntityRelationshipName: props.otherEntityRelationshipName
+            };
+
+            if (props.otherEntityName.toLowerCase() === 'user') {
+                relationship.ownerSide = true;
+                relationship.otherEntityField = 'login';
+                relationship.otherEntityRelationshipName = _.lowerFirst(name);
+            }
+
+            fieldNamesUnderscored.push(_.snakeCase(props.relationshipName));
+            context.relationships.push(relationship);
+        }
+        logFieldsAndRelationships.call(this);
+        if (props.relationshipAdd) {
+            askForRelationship.call(this, done);
+        } else {
+            this.log('\n');
+            done();
+        }
+    });
+}
+
+/**
+ * Show the entity and it's fields and relationships in console
+ */
+function logFieldsAndRelationships() {
+    const context = this.context;
+    if (context.fields.length > 0 || context.relationships.length > 0) {
+        this.log(chalk.red(chalk.white('\n================= ') + context.entityNameCapitalized + chalk.white(' =================')));
+    }
+    if (context.fields.length > 0) {
+        this.log(chalk.white('Fields'));
+        context.fields.forEach(field => {
+            const validationDetails = [];
+            const fieldValidate = _.isArray(field.fieldValidateRules) && field.fieldValidateRules.length >= 1;
+            if (fieldValidate === true) {
+                if (field.fieldValidateRules.includes('required')) {
+                    validationDetails.push('required');
+                }
+                if (field.fieldValidateRules.includes('unique')) {
+                    validationDetails.push('unique');
+                }
+                if (field.fieldValidateRules.includes('minlength')) {
+                    validationDetails.push(`minlength='${field.fieldValidateRulesMinlength}'`);
+                }
+                if (field.fieldValidateRules.includes('maxlength')) {
+                    validationDetails.push(`maxlength='${field.fieldValidateRulesMaxlength}'`);
+                }
+                if (field.fieldValidateRules.includes('pattern')) {
+                    validationDetails.push(`pattern='${field.fieldValidateRulesPattern}'`);
+                }
+                if (field.fieldValidateRules.includes('min')) {
+                    validationDetails.push(`min='${field.fieldValidateRulesMin}'`);
+                }
+                if (field.fieldValidateRules.includes('max')) {
+                    validationDetails.push(`max='${field.fieldValidateRulesMax}'`);
+                }
+                if (field.fieldValidateRules.includes('minbytes')) {
+                    validationDetails.push(`minbytes='${field.fieldValidateRulesMinbytes}'`);
+                }
+                if (field.fieldValidateRules.includes('maxbytes')) {
+                    validationDetails.push(`maxbytes='${field.fieldValidateRulesMaxbytes}'`);
+                }
+            }
+            this.log(
+                chalk.red(field.fieldName) +
+                    chalk.white(` (${field.fieldType}${field.fieldTypeBlobContent ? ` ${field.fieldTypeBlobContent}` : ''}) `) +
+                    chalk.cyan(validationDetails.join(' '))
+            );
+        });
+        this.log();
+    }
+    if (context.relationships.length > 0) {
+        this.log(chalk.white('Relationships'));
+        context.relationships.forEach(relationship => {
+            const validationDetails = [];
+            if (relationship.relationshipValidateRules && relationship.relationshipValidateRules.includes('required')) {
+                validationDetails.push('required');
+            }
+            this.log(
+                `${chalk.red(relationship.relationshipName)} ${chalk.white(`(${_.upperFirst(relationship.otherEntityName)})`)} ${chalk.cyan(
+                    relationship.relationshipType
+                )} ${chalk.cyan(validationDetails.join(' '))}`
+            );
+        });
+        this.log();
+    }
+}

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -56,7 +56,7 @@ module.exports = class extends ServerGenerator {
             displayLogo() {
                 this.printJHipsterNetLogo();
             },
-            setupServeronsts() {
+            setupServerConsts() {
                 this.packagejs = packagejs;
                 this.jhipsterNetVersion = packagejs.version;
                 const configuration = this.getAllJhipsterConfig(this, true);

--- a/generators/server/templates/dotnetcore/test/Project.Test/Controllers/TestUtil.cs.ejs
+++ b/generators/server/templates/dotnetcore/test/Project.Test/Controllers/TestUtil.cs.ejs
@@ -13,10 +13,16 @@
  limitations under the License.
 -%>
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Newtonsoft.Json;
 
 namespace <%= namespace %>.Test.Controllers {
@@ -59,6 +65,153 @@ namespace <%= namespace %>.Test.Controllers {
         {
 //            var mock = new Mock<HttpContext>();
 //            mock.Setup(httpContext => httpContext.User).Returns(null);
+        }
+
+        /// <summary>
+        /// Compare entity instances of a DbContext using Reflection.
+        /// Precondition : objects must be of the same type.
+        /// Returns true if the objects are the same, false otherwise.
+        /// </summary>
+        /// <param name="inputObjectA"></param>
+        /// <param name="inputObjectB"></param>
+        /// <param name="ignorePropertiesList"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static bool CompareObjects(object inputObjectA, object inputObjectB, HashSet<string> ignorePropertiesList, DbContext context)
+        {
+            bool areObjectsEqual = true;
+
+            if (inputObjectA != null && inputObjectB != null) {
+                object value1, value2;
+                HashSet<string> ignorePropertiesListForChildren = TestUtil.GetNavigationProperties(context, inputObjectA.GetType());
+                PropertyInfo[] properties = inputObjectA.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+                foreach (PropertyInfo propertyInfo in properties) {
+                    if (!propertyInfo.CanRead || ignorePropertiesList.Contains(propertyInfo.Name))
+                        continue;
+
+                    value1 = propertyInfo.GetValue(inputObjectA);
+                    value2 = propertyInfo.GetValue(inputObjectB);
+
+                    if (IsAssignableFrom(propertyInfo.PropertyType) || IsPrimitiveType(propertyInfo.PropertyType) || IsValueType(propertyInfo.PropertyType)) {
+                        if (!CompareValues(value1, value2)) {
+                            areObjectsEqual = false;
+                        }
+                    }
+                    else if (IsEnumerableType(propertyInfo.PropertyType)) {
+                        HashSet<string> ignorePropertiesListUnion = new HashSet<string>(ignorePropertiesList);
+                        ignorePropertiesListUnion.UnionWith(ignorePropertiesListForChildren);
+                        if (!CompareEnumerations(value1, value2, ignorePropertiesListUnion, context)) {
+                            areObjectsEqual = false;
+                        }
+                    }
+                    else if (propertyInfo.PropertyType.IsClass) {
+                        HashSet<string> ignorePropertiesListUnion = new HashSet<string>(ignorePropertiesList);
+                        ignorePropertiesListUnion.UnionWith(ignorePropertiesListForChildren);
+                        if (!CompareObjects(propertyInfo.GetValue(inputObjectA), propertyInfo.GetValue(inputObjectB), ignorePropertiesListUnion, context)) {
+                            areObjectsEqual = false;
+                        }
+                    }
+                    else {
+                        areObjectsEqual = false;
+                    }
+
+                    if (!areObjectsEqual)
+                        break;
+                }
+            }
+            else if (inputObjectA == null && inputObjectB != null || inputObjectA != null && inputObjectB == null)
+                areObjectsEqual = false;
+
+            return areObjectsEqual;
+        }
+
+        private static bool IsAssignableFrom(Type type)
+        {
+            return typeof(IComparable).IsAssignableFrom(type);
+        }
+
+        private static bool IsPrimitiveType(Type type)
+        {
+            return type.IsPrimitive;
+        }
+
+        private static bool IsValueType(Type type)
+        {
+            return type.IsValueType;
+        }
+
+        private static bool IsEnumerableType(Type type)
+        {
+            return (typeof(IEnumerable).IsAssignableFrom(type));
+        }
+
+        private static bool CompareValues(object value1, object value2)
+        {
+            bool areValuesEqual = true;
+            IComparable selfValueComparer = value1 as IComparable;
+
+            if (value1 == null && value2 != null || value1 != null && value2 == null)
+                areValuesEqual = false;
+            else if (selfValueComparer != null && selfValueComparer.CompareTo(value2) != 0)
+                areValuesEqual = false;
+            else if (!object.Equals(value1, value2))
+                areValuesEqual = false;
+
+            return areValuesEqual;
+        }
+
+        private static bool CompareEnumerations(object value1, object value2, HashSet<string> ignorePropertiesList, DbContext context)
+        {
+            if (value1 == null && value2 != null || value1 != null && value2 == null)
+                return false;
+            else if (value1 != null && value2 != null) {
+                IEnumerable<object> enumValue1, enumValue2;
+                enumValue1 = ((IEnumerable)value1).Cast<object>();
+                enumValue2 = ((IEnumerable)value2).Cast<object>();
+
+                if (enumValue1.Count() != enumValue2.Count())
+                    return false;
+                else {
+                    object enumValue1Item, enumValue2Item;
+                    Type enumValue1ItemType;
+                    for (int itemIndex = 0; itemIndex < enumValue1.Count(); itemIndex++) {
+                        enumValue1Item = enumValue1.ElementAt(itemIndex);
+                        enumValue2Item = enumValue2.ElementAt(itemIndex);
+                        enumValue1ItemType = enumValue1Item.GetType();
+                        if (IsAssignableFrom(enumValue1ItemType) || IsPrimitiveType(enumValue1ItemType) || IsValueType(enumValue1ItemType)) {
+                            if (!CompareValues(enumValue1Item, enumValue2Item))
+                                return false;
+                        }
+                        else if (!CompareObjects(enumValue1Item, enumValue2Item, ignorePropertiesList, context))
+                            return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        public static HashSet<string> GetNavigationProperties(DbContext context, Type clrEntityType)
+        {
+            HashSet<string> navigationProperties = new HashSet<string>();
+            var entityType = context.Model.FindEntityType(clrEntityType);
+
+            if (entityType != null) {
+                var navigations = entityType.GetNavigations();
+                PropertyInfo[] properties = clrEntityType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+                foreach (INavigation nav in navigations) {
+                    navigationProperties.Add(nav.PropertyInfo.Name);
+                }
+
+                foreach (PropertyInfo propertyInfo in properties) {
+                    if (propertyInfo.GetCustomAttributes(typeof(NotMappedAttribute), true).Count() > 0) {
+                        navigationProperties.Add(propertyInfo.Name);
+                    }
+                }
+            }
+
+            return navigationProperties;
         }
     }
 }


### PR DESCRIPTION
- In generated tests :
Replaces the creation of related entity instances with factory calls.
The comparisons of related entity instances are now performed by reflection.

- Also, it is now possible to create many many-to-many relationships between two same entities.