### PR TITLE
Update dockerfile generator to .net core 3.0 and nodejs v12

### DIFF
--- a/generators/common/templates/dotnetcore/src/Project/Dockerfile.ejs
+++ b/generators/common/templates/dotnetcore/src/Project/Dockerfile.ejs
@@ -12,7 +12,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
 WORKDIR /app
 COPY ["src/JHipsterNet/JHipsterNet.csproj", "src/JHipsterNet/"]
 COPY ["src/<%= mainProjectDir %>/<%= pascalizedBaseName %>.csproj", "src/<%= mainProjectDir %>/"]
@@ -20,7 +20,7 @@ RUN dotnet restore "src/<%= mainProjectDir %>/<%= pascalizedBaseName %>.csproj"
 COPY . ./
 WORKDIR /app/src/<%= mainProjectDir %>
 RUN apt-get update -yq && apt-get install -yq curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get update && \
     apt-get install -yq nodejs && \
     rm -rf /var/lib/apt/lists/*
@@ -28,7 +28,7 @@ RUN npm install
 RUN rm -rf wwwroot && \
     dotnet publish "<%= pascalizedBaseName %>.csproj" -c Release -o /app/out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
 WORKDIR /app
 EXPOSE 80
 COPY --from=build /app/out .


### PR DESCRIPTION
Noticed errors running the generated Dokerfile because .Net core version was updated to 3.0 leading to errors due to v2.2 was used in docker according to issue #45. 
So I updated the generator for the dockerfile to .net core 3.0 and also updated dockerfile's node version to 12 to keep up with issue #50.