### PR TITLE
Bumped the JCore dependency to v7.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5086,9 +5086,9 @@
       }
     },
     "jhipster-core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-7.2.0.tgz",
-      "integrity": "sha512-25GGx7xonnQye7l0RQsi18xGuJf5GujvoiYy3qRHW6vEeQMQhCK5SdOwH40uh7VVYPWVpcAHNl2281+xj5AO3g==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-7.2.1.tgz",
+      "integrity": "sha512-GbfbyFR5k4dIHGVfFEBQyumULwH+1XAeZlpKjel8QoiS9S2Oxs7wUIfedDJimQ4hFLlDtqhWQE60IPD3BAzXJQ==",
       "requires": {
         "chevrotain": "6.5.0",
         "fs-extra": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "glob": "7.1.3",
     "gulp-filter": "5.1.0",
     "insight": "0.10.1",
-    "jhipster-core": "7.2.0",
+    "jhipster-core": "7.2.1",
     "js-yaml": "3.13.1",
     "lodash": "4.17.13",
     "meow": "5.0.0",


### PR DESCRIPTION
There was an issue when parsing a JDL content with applications but no entity. This issue is fixed in this version.

Sorry about that.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
