### PR TITLE
added migrations documetation and missing package

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,42 @@ docker-compose -f docker/app.yml up
 
 In case of Oracle database, see [official documentation](https://github.com/oracle/docker-images/blob/master/OracleDatabase/SingleInstance/README.md)
 
+
+## Using database migrations
+
+If you had alredy run the application before creating your first migration, some database tables might be alredy 
+created automatically on application startup (see EnsureCreated() method on DatabaseStartup.cs file for more details).
+So you have the options of removing conflicting tables or editing the migration you just created.
+Also, currently it is up to the user to create migrations.
+
+1. Add EF Core cli tools
+
+With .net core 3.0 the cli tool for entity framework was removed from the core sdk so you need to install it globally. 
+You only need to do this once. See [Breaking changes included in EF Core 3.0](https://docs.microsoft.com/pt-br/ef/core/what-is-new/ef-core-3.0/breaking-changes#dotnet-ef) for reference.
+
+```bash
+dotnet tool install --global dotnet-ef
+```
+
+If using Visual Studio follow the documentation on [Entity Framework Core tools reference - Package Manager Console in Visual Studio](https://docs.microsoft.com/pt-br/ef/core/miscellaneous/cli/powershell)
+
+2. Create the initial database migration
+
+```bash
+dotnet ef migrations add InitialCreate --project YourProject.csproj
+```
+
+3. Update the database
+
+```bash
+dotnet ef database update --project YourProject.csproj
+```
+
+Tips: 
+- Remember to change the connection string to point to your database at appsettings.json.
+- It is a good practice to check your migration files and backup your database before running migrations.
+
+
 # Running SonarQube
 
 ## By Script : 

--- a/README.md
+++ b/README.md
@@ -162,10 +162,12 @@ In case of Oracle database, see [official documentation](https://github.com/orac
 
 ## Using database migrations
 
-If you had alredy run the application before creating your first migration, some database tables might be alredy 
-created automatically on application startup (see EnsureCreated() method on DatabaseStartup.cs file for more details).
+If you had already run the application before creating your first migration, some database tables might be alredy 
+created automatically on application startup.
 So you have the options of removing conflicting tables or editing the migration you just created.
-Also, currently it is up to the user to create migrations.
+If you wish to automatically apply database migrations when the application is started replace method 
+EnsureCreated() by Migrate() at DatabaseStartup.cs file. Be aware of the implications of doing so.
+Currently it is up to the user to create migrations.
 
 1. Add EF Core cli tools
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ In case of Oracle database, see [official documentation](https://github.com/orac
 
 ## Using database migrations
 
-If you had already run the application before creating your first migration, some database tables might be alredy 
+If you had already run the application before creating your first migration, some database tables might be already 
 created automatically on application startup.
 So you have the options of removing conflicting tables or editing the migration you just created.
 If you wish to automatically apply database migrations when the application is started replace method 

--- a/generators/server/templates/dotnetcore/src/Project/Project.csproj.ejs
+++ b/generators/server/templates/dotnetcore/src/Project/Project.csproj.ejs
@@ -62,12 +62,12 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
             case 'oracle': _%>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
         <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.60" />
         <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6" />
             <%_ break;
          } _%>
         <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/generators/server/templates/dotnetcore/src/Project/Project.csproj.ejs
+++ b/generators/server/templates/dotnetcore/src/Project/Project.csproj.ejs
@@ -62,9 +62,9 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
             case 'oracle': _%>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.1" />
         <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.60" />
         <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />

--- a/generators/server/templates/dotnetcore/src/Project/Project.csproj.ejs
+++ b/generators/server/templates/dotnetcore/src/Project/Project.csproj.ejs
@@ -43,20 +43,23 @@
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
             case 'mssql': _%>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
             case 'postgres': _%>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
             case 'mysql': _%>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.1" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
             case 'oracle': _%>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
@@ -64,6 +67,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
         <PackageReference Include="Oracle.EntityFrameworkCore" Version="2.19.60" />
         <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.60" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
             <%_ break;
          } _%>
         <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />


### PR DESCRIPTION
this adds documentation on working with migrations
and also adds Microsoft.EntityFrameworkCore.Tools package
which adds missing packages required to create migrations

Fix #212