### PR TITLE
Fix NullReferenceException related to sorting/paging (#229)

### DIFF
--- a/generators/server/templates/dotnetcore/src/JHipsterNet/Pagination/Extensions/QueryStringExtensions.cs.ejs
+++ b/generators/server/templates/dotnetcore/src/JHipsterNet/Pagination/Extensions/QueryStringExtensions.cs.ejs
@@ -23,11 +23,12 @@ namespace JHipsterNet.Pagination.Extensions {
             var parameters = QueryHelpers.ParseQuery(query.ToString());
             return parameters.ContainsKey(name) ? parameters[name][0] : null;
         }
+
         public static string[] GetParameterValues(this QueryString query, string name)
         {
-            if (query == null || string.IsNullOrEmpty(name)) return null;
+            if (query == null || string.IsNullOrEmpty(name)) return new string[0];
             var parameters = QueryHelpers.ParseQuery(query.ToString());
-            return parameters.ContainsKey(name) ? parameters[name].ToArray() : null;
+            return parameters.ContainsKey(name) ? parameters[name].ToArray() :  new string[0];
         }
     }
 }


### PR DESCRIPTION
The code that calls the GetParameterValues method throws
NullReferenceException because it expects a string[]
not null.

Fix #229

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
