### PR TITLE
Add variable jhipsterDotnetVersion to auto update ReadMe.md

### DIFF
--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -22,6 +22,7 @@ const CommonGenerator = require('generator-jhipster/generators/common');
 const toPascalCase = require('to-pascal-case');
 const _ = require('lodash');
 const writeFiles = require('./files').writeFiles;
+const packagejs = require('../../package.json');
 
 module.exports = class extends CommonGenerator {
     constructor(args, opts) {
@@ -47,6 +48,7 @@ module.exports = class extends CommonGenerator {
                 this.pascalizedBaseName = toPascalCase(this.baseName);
                 this.mainProjectDir = this.pascalizedBaseName;
                 this.mainClientDir = `${this.mainProjectDir}/ClientApp`;
+                this.jhipsterDotnetVersion = packagejs.version;
             },
         };
     }

--- a/generators/common/templates/dotnetcore/README.md.ejs
+++ b/generators/common/templates/dotnetcore/README.md.ejs
@@ -20,7 +20,7 @@
 <%_
 let DOCUMENTATION_ARCHIVE_URL = `${DOCUMENTATION_URL + DOCUMENTATION_ARCHIVE_PATH}v${jhipsterVersion}`;
 _%>
-This application was generated using JHipster <%= jhipsterVersion %> and JHipster .Net Core 1.0.0, you can find documentation and help at [<%= DOCUMENTATION_ARCHIVE_URL %>](<%= DOCUMENTATION_ARCHIVE_URL %>).
+This application was generated using JHipster <%= jhipsterVersion %> and JHipster .Net Core <%= jhipsterDotnetVersion %>, you can find documentation and help at [<%= DOCUMENTATION_ARCHIVE_URL %>](<%= DOCUMENTATION_ARCHIVE_URL %>).
 
 ## Development
 


### PR DESCRIPTION
Issue #267 

Added a jhipsterDotnetVersion variable to automatically generate the README.md
I used the package.json file to get the version (most reliable and simple way to get it as I see it)

✅ README.md does print out the right version of the package

