### PR TITLE
don't update devDependencies using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      time: '11:00'
-    open-pull-requests-limit: 10
-    target-branch: 'main'
   - package-ecosystem: 'nuget'
     directory: '/generators/dotnetcore/templates/dotnetcore/src/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '11:00'
+    open-pull-requests-limit: 10
+    target-branch: 'main'
+    allow:
+      - dependency-type: 'production'
   - package-ecosystem: 'nuget'
     directory: '/generators/dotnetcore/templates/dotnetcore/src/'
     schedule:


### PR DESCRIPTION
devDependencies should be updated using `jhipster generate-blueprint` command

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
