### PR TITLE
Generate relationship persistence tests

### DIFF
--- a/generators/blazor/__snapshots__/generator.spec.js.snap
+++ b/generators/blazor/__snapshots__/generator.spec.js.snap
@@ -330,7 +330,7 @@ exports[`SubGenerator blazor of dotnetcore JHipster blueprint > run > execute co
 [
   [
     "spawnCommand",
-    "dotnet new sln --name Jhipster",
+    "dotnet new sln --name Jhipster --format sln",
   ],
   [
     "spawnCommand",

--- a/generators/blazor/generator.js
+++ b/generators/blazor/generator.js
@@ -177,7 +177,7 @@ export default class extends BaseApplicationGenerator {
           try {
             await access(`${application.solutionName}.sln`);
           } catch {
-            await this.spawnCommand(`dotnet new sln --name ${application.solutionName}`);
+            await this.spawnCommand(`dotnet new sln --name ${application.solutionName} --format sln`);
           }
         } catch (err) {
           this.log.warn(`Failed to create ${application.solutionName} .Net Core solution: ${err}`);

--- a/generators/dotnetcore/__snapshots__/generator.spec.js.snap
+++ b/generators/dotnetcore/__snapshots__/generator.spec.js.snap
@@ -4,7 +4,7 @@ exports[`SubGenerator dotnetcore of dotnetcore JHipster blueprint > run > execut
 [
   [
     "spawnCommand",
-    "dotnet new sln --name Jhipster",
+    "dotnet new sln --name Jhipster --format sln",
   ],
   [
     "spawnCommand",

--- a/generators/dotnetcore/generator.js
+++ b/generators/dotnetcore/generator.js
@@ -243,7 +243,7 @@ export default class extends BaseApplicationGenerator {
       await access(`${solutionName}.sln`);
       return true;
     } catch {
-      return this.spawnCommand(`dotnet new sln --name ${solutionName}`);
+      return this.spawnCommand(`dotnet new sln --name ${solutionName} --format sln`);
     }
   }
 

--- a/generators/dotnetcore/generator.spec.js
+++ b/generators/dotnetcore/generator.spec.js
@@ -255,4 +255,69 @@ describe('SubGenerator dotnetcore of dotnetcore JHipster blueprint', () => {
       result.assertFileContent(personServiceInterface, /public interface IPersonService/);
     });
   });
+
+  describe('generating relationship tests', () => {
+    const employeeTest = `${SERVER_SRC_DIR.replace('src/', 'test/')}JhipsterBlueprint.Test/Controllers/EmployeeControllerIntTest.cs`;
+
+    beforeAll(async function () {
+      await helpers
+        .run(SUB_GENERATOR_NAMESPACE)
+        .withJHipsterConfig(
+          {
+            baseName: 'jhipsterBlueprint',
+          },
+          [
+            {
+              name: 'Department',
+              fields: [
+                {
+                  fieldName: 'name',
+                  fieldType: 'String',
+                },
+              ],
+            },
+            {
+              name: 'Employee',
+              fields: [
+                {
+                  fieldName: 'name',
+                  fieldType: 'String',
+                },
+              ],
+              relationships: [
+                {
+                  relationshipType: 'many-to-one',
+                  relationshipName: 'department',
+                  otherEntityName: 'department',
+                  otherEntityField: 'name',
+                },
+                {
+                  relationshipType: 'many-to-one',
+                  relationshipName: 'manager',
+                  otherEntityName: 'employee',
+                  otherEntityField: 'name',
+                },
+              ],
+            },
+          ],
+        )
+        .withOptions({
+          ignoreNeedlesError: true,
+          blueprints: 'dotnetcore',
+        })
+        .withJHipsterLookup()
+        .withSpawnMock()
+        .withParentBlueprintLookup();
+    });
+
+    it('generates create and remove tests for optional many-to-one relationships', () => {
+      result.assertFile(employeeTest);
+      result.assertFileContent(employeeTest, /private readonly IDepartmentRepository _departmentRepository;/);
+      result.assertFileContent(employeeTest, /CreateEmployeeWithDepartmentRelationship/);
+      result.assertFileContent(employeeTest, /RemoveDepartmentRelationshipFromEmployee/);
+      result.assertFileContent(employeeTest, /testEmployee\.DepartmentId\.Should\(\)\.Be\(department\.Id\);/);
+      result.assertFileContent(employeeTest, /testEmployee\.Department\.Should\(\)\.BeNull\(\);/);
+      result.assertNoFileContent(employeeTest, /CreateEmployeeWithManagerRelationship/);
+    });
+  });
 });

--- a/generators/dotnetcore/templates/dotnetcore/src/Project.Infrastructure/Data/ApplicationDatabaseContext.cs.ejs
+++ b/generators/dotnetcore/templates/dotnetcore/src/Project.Infrastructure/Data/ApplicationDatabaseContext.cs.ejs
@@ -92,10 +92,10 @@ public class ApplicationDatabaseContext : DbContext
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
     {
         var entries = ChangeTracker
-          .Entries()
-          .Where(e => e.Entity is IAuditedEntityBase && (
-              e.State == EntityState.Added
-              || e.State == EntityState.Modified));
+            .Entries()
+            .Where(e => e.Entity is IAuditedEntityBase && (
+                e.State == EntityState.Added
+                || e.State == EntityState.Modified));
 
         string modifiedOrCreatedBy = _httpContextAccessor?.HttpContext?.User?.Identity?.Name ?? "System";
 
@@ -111,7 +111,7 @@ public class ApplicationDatabaseContext : DbContext
                 Entry((IAuditedEntityBase)entityEntry.Entity).Property(p => p.CreatedDate).IsModified = false;
                 Entry((IAuditedEntityBase)entityEntry.Entity).Property(p => p.CreatedBy).IsModified = false;
             }
-          ((IAuditedEntityBase)entityEntry.Entity).LastModifiedDate = DateTime.Now;
+            ((IAuditedEntityBase)entityEntry.Entity).LastModifiedDate = DateTime.Now;
             ((IAuditedEntityBase)entityEntry.Entity).LastModifiedBy = modifiedOrCreatedBy;
         }
         return await base.SaveChangesAsync(cancellationToken);

--- a/generators/dotnetcore/templates/dotnetcore/src/Project.Infrastructure/Data/ApplicationDatabaseContext_withEntities_.cs.ejs
+++ b/generators/dotnetcore/templates/dotnetcore/src/Project.Infrastructure/Data/ApplicationDatabaseContext_withEntities_.cs.ejs
@@ -174,10 +174,10 @@ namespace <%= namespace %>.Infrastructure.Data
         public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var entries = ChangeTracker
-              .Entries()
-              .Where(e => e.Entity is IAuditedEntityBase && (
-                  e.State == EntityState.Added
-                  || e.State == EntityState.Modified));
+                .Entries()
+                .Where(e => e.Entity is IAuditedEntityBase && (
+                    e.State == EntityState.Added
+                    || e.State == EntityState.Modified));
 
             string modifiedOrCreatedBy = _httpContextAccessor?.HttpContext?.User?.Identity?.Name ?? "System";
 
@@ -193,7 +193,7 @@ namespace <%= namespace %>.Infrastructure.Data
                     Entry((IAuditedEntityBase)entityEntry.Entity).Property(p => p.CreatedDate).IsModified = false;
                     Entry((IAuditedEntityBase)entityEntry.Entity).Property(p => p.CreatedBy).IsModified = false;
                 }
-              ((IAuditedEntityBase)entityEntry.Entity).LastModifiedDate = DateTime.Now;
+                ((IAuditedEntityBase)entityEntry.Entity).LastModifiedDate = DateTime.Now;
                 ((IAuditedEntityBase)entityEntry.Entity).LastModifiedBy = modifiedOrCreatedBy;
             }
             return await base.SaveChangesAsync(cancellationToken);

--- a/generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs
+++ b/generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs
@@ -157,9 +157,22 @@ function hasDateTimeTypeField(fields) {
         idx ++;
     }
     return dateTimeTypeField;
+}
+function relationshipFields(relationship) {
+    return relationship.otherEntity?.fields ?? relationship.otherEntity?.definition?.fields ?? [];
 } _%>
 <%
 let hasDto = dto === 'mapstruct';
+const relationshipsToTest = databaseType !== 'mongodb'
+    ? relationships.filter(relationship =>
+        (relationship.relationshipType === 'many-to-one' || relationship.relationshipType === 'one-to-one') &&
+        relationship.otherEntityNameLowerCased !== 'user' &&
+        relationship.otherEntityNamePascalized !== pascalizedEntityClass
+    )
+    : [];
+const relationshipEntitiesToTest = relationshipsToTest.filter((relationship, index, source) =>
+    source.findIndex(item => item.otherEntityNamePascalized === relationship.otherEntityNamePascalized) === index
+);
 %>
 <%_ if (hasDto) { _%>
 using AutoMapper;
@@ -183,6 +196,13 @@ fields.forEach(field => {
             hasEnumField = true;
         }
     });
+relationshipEntitiesToTest.forEach(relationship => {
+    relationshipFields(relationship).forEach(field => {
+        if (field.fieldIsEnum) {
+            hasEnumField = true;
+        }
+    });
+});
 if (hasEnumField) { _%>
 using <%= namespace %>.Crosscutting.Enums;
 <%_ } _%>
@@ -211,6 +231,9 @@ namespace <%= namespace %>.Test.Controllers
             _client = _factory.CreateClient();
 
             _<%= camelCasedEntityClass %>Repository = _factory.GetRequiredService<I<%= pascalizedEntityClass %>Repository>();
+            <%_ relationshipEntitiesToTest.forEach(relationship => { _%>
+            _<%= relationship.otherEntityNameCamelCased %>Repository = _factory.GetRequiredService<I<%= relationship.otherEntityNamePascalized %>Repository>();
+            <%_ }); _%>
 
             <%_ if (hasDto) { _%>
             var config = new MapperConfiguration(cfg =>
@@ -241,6 +264,9 @@ namespace <%= namespace %>.Test.Controllers
         private readonly AppWebApplicationFactory<TestStartup> _factory;
         private readonly HttpClient _client;
         private readonly I<%= pascalizedEntityClass %>Repository _<%= camelCasedEntityClass %>Repository;
+        <%_ relationshipEntitiesToTest.forEach(relationship => { _%>
+        private readonly I<%= relationship.otherEntityNamePascalized %>Repository _<%= relationship.otherEntityNameCamelCased %>Repository;
+        <%_ }); _%>
 
         private <%= pascalizedEntityClass %> _<%= camelCasedEntityClass %>;
 
@@ -265,6 +291,23 @@ namespace <%= namespace %>.Test.Controllers
                 <%_ } _%>
             };
         }
+        <%_ relationshipEntitiesToTest.forEach(relationship => { _%>
+
+        private <%= relationship.otherEntityNamePascalized %> Create<%= relationship.otherEntityNamePascalized %>Entity()
+        {
+            return new <%= relationship.otherEntityNamePascalized %>
+            {
+                <%_ relationshipFields(relationship).forEach(field => {
+                    if (field.id) return;
+                    if (field.fieldIsEnum) { _%>
+                <%= field.fieldNamePascalized %> = <%- enumDefaultValue(field) %>,
+                    <%_ } else { _%>
+                <%= field.fieldNamePascalized %> = <%- defaultValue(getNullableResolvedType(field.cSharpType, true)) %>,
+                    <%_ }
+                }); _%>
+            };
+        }
+        <%_ }); _%>
 
         private void InitTest()
         {
@@ -294,6 +337,61 @@ namespace <%= namespace %>.Test.Controllers
             test<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %>.Should().Be(Default<%= field.fieldNamePascalized %>);
             <%_ }); _%>
         }
+        <%_ relationshipsToTest.forEach(relationship => { _%>
+
+        [Fact]
+        public async Task Create<%= pascalizedEntityClass %>With<%= relationship.relationshipFieldNamePascalized %>Relationship()
+        {
+            var databaseSizeBeforeCreate = await _<%= camelCasedEntityClass %>Repository.CountAsync();
+            var <%= relationship.otherEntityNameCamelCased %> = Create<%= relationship.otherEntityNamePascalized %>Entity();
+            await _<%= relationship.otherEntityNameCamelCased %>Repository.CreateOrUpdateAsync(<%= relationship.otherEntityNameCamelCased %>);
+            await _<%= relationship.otherEntityNameCamelCased %>Repository.SaveChangesAsync();
+
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = <%= relationship.otherEntityNameCamelCased %>;
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id = <%= relationship.otherEntityNameCamelCased %>.Id;
+
+            await _<%= camelCasedEntityClass %>Repository.CreateOrUpdateAsync(_<%= camelCasedEntityClass %>);
+            await _<%= camelCasedEntityClass %>Repository.SaveChangesAsync();
+
+            var <%= camelCasedEntityClass %>List = await _<%= camelCasedEntityClass %>Repository.GetAllAsync();
+            <%= camelCasedEntityClass %>List.Count().Should().Be(databaseSizeBeforeCreate + 1);
+            var test<%= pascalizedEntityClass %> = await _<%= camelCasedEntityClass %>Repository.QueryHelper()
+                .Include(<%= camelCasedEntityClass %> => <%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>)
+                .GetOneAsync(<%= camelCasedEntityClass %> => <%= camelCasedEntityClass %>.Id == _<%= camelCasedEntityClass %>.Id);
+            test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id.Should().Be(<%= relationship.otherEntityNameCamelCased %>.Id);
+            test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>.Should().NotBeNull();
+        }
+        <%_ if (!relationship.relationshipRequired) { _%>
+
+        [Fact]
+        public async Task Remove<%= relationship.relationshipFieldNamePascalized %>RelationshipFrom<%= pascalizedEntityClass %>()
+        {
+            var <%= relationship.otherEntityNameCamelCased %> = Create<%= relationship.otherEntityNamePascalized %>Entity();
+            await _<%= relationship.otherEntityNameCamelCased %>Repository.CreateOrUpdateAsync(<%= relationship.otherEntityNameCamelCased %>);
+            await _<%= relationship.otherEntityNameCamelCased %>Repository.SaveChangesAsync();
+
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = <%= relationship.otherEntityNameCamelCased %>;
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id = <%= relationship.otherEntityNameCamelCased %>.Id;
+            await _<%= camelCasedEntityClass %>Repository.CreateOrUpdateAsync(_<%= camelCasedEntityClass %>);
+            await _<%= camelCasedEntityClass %>Repository.SaveChangesAsync();
+
+            var persisted<%= pascalizedEntityClass %> = await _<%= camelCasedEntityClass %>Repository.QueryHelper()
+                .Include(<%= camelCasedEntityClass %> => <%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>)
+                .GetOneAsync(<%= camelCasedEntityClass %> => <%= camelCasedEntityClass %>.Id == _<%= camelCasedEntityClass %>.Id);
+            persisted<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = null;
+            persisted<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id = default;
+
+            await _<%= camelCasedEntityClass %>Repository.CreateOrUpdateAsync(persisted<%= pascalizedEntityClass %>);
+            await _<%= camelCasedEntityClass %>Repository.SaveChangesAsync();
+
+            var test<%= pascalizedEntityClass %> = await _<%= camelCasedEntityClass %>Repository.QueryHelper()
+                .Include(<%= camelCasedEntityClass %> => <%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>)
+                .GetOneAsync(<%= camelCasedEntityClass %> => <%= camelCasedEntityClass %>.Id == _<%= camelCasedEntityClass %>.Id);
+            test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id.Should().Be(default(<%= relationship.otherEntity.primaryKeyType %>));
+            test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>.Should().BeNull();
+        }
+        <%_ } _%>
+        <%_ }); _%>
 
         [Fact]
         public async Task Create<%= pascalizedEntityClass %>WithExistingId()

--- a/generators/xamarin/__snapshots__/generator.spec.js.snap
+++ b/generators/xamarin/__snapshots__/generator.spec.js.snap
@@ -4,7 +4,7 @@ exports[`SubGenerator xamarin of dotnetcore JHipster blueprint > run > execute c
 [
   [
     "spawnCommand",
-    "dotnet new sln --name Jhipster",
+    "dotnet new sln --name Jhipster --format sln",
   ],
   [
     "spawnCommand",

--- a/generators/xamarin/generator.js
+++ b/generators/xamarin/generator.js
@@ -120,7 +120,7 @@ export default class extends BaseApplicationGenerator {
         this.log(chalk.green.bold(`\nCreating ${application.solutionName} .Net Core solution if it does not already exist.\n`));
 
         try {
-          await this.spawnCommand(`dotnet new sln --name ${application.solutionName}`);
+          await this.spawnCommand(`dotnet new sln --name ${application.solutionName} --format sln`);
         } catch (err) {
           this.log.warn(`Failed to create ${application.solutionName} .Net Core solution: ${err}`);
         }


### PR DESCRIPTION
Fixes #397.

## Summary

- Generate repository-level relationship persistence tests for optional non-self `many-to-one` and `one-to-one` entity relationships.
- Add related-entity test fixture creation and repository injection to generated controller integration tests.
- Cover the generated `Employee -> Department` case with generator assertions so the relationship create/remove test output is locked.
- Skip self-referential relationships in this first pass to avoid duplicate repository members in generated tests.

## Validation

- `npx vitest run generators/dotnetcore/generator.spec.js --testNamePattern 'generating relationship tests'`
- `npm run ejslint -- generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs`
- `npx vitest run generators/dotnetcore/generator.spec.js`
- `npm run lint -- --quiet`
- `npm run prettier-check -- generators/dotnetcore/generator.spec.js`
- `npm test`
- `cli/cli.cjs generate-sample microservice-app --skip-install --skip-checks --no-insight --with-entities` from a clean temp directory
