### PR TITLE
Add generated controller tests for related entities

### DIFF
--- a/generators/blazor/__snapshots__/generator.spec.js.snap
+++ b/generators/blazor/__snapshots__/generator.spec.js.snap
@@ -334,7 +334,7 @@ exports[`SubGenerator blazor of dotnetcore JHipster blueprint > run > execute co
   ],
   [
     "spawnCommand",
-    "dotnet sln Jhipster.sln add src/client/Jhipster.Client/Jhipster.Client.csproj src/client/Jhipster.Client.Shared/Jhipster.Client.Shared.csproj test/Jhipster.Client.Test/Jhipster.Client.Test.csproj",
+    "dotnet sln Jhipster.slnx add src/client/Jhipster.Client/Jhipster.Client.csproj src/client/Jhipster.Client.Shared/Jhipster.Client.Shared.csproj test/Jhipster.Client.Test/Jhipster.Client.Test.csproj",
   ],
   [
     "spawnCommand",

--- a/generators/blazor/generator.js
+++ b/generators/blazor/generator.js
@@ -173,12 +173,9 @@ export default class extends BaseApplicationGenerator {
     return this.asEndTaskGroup({
       async end({ application }) {
         this.log(chalk.green.bold(`\nCreating ${application.solutionName} .Net Core solution if it does not already exist.\n`));
+        let solutionFile;
         try {
-          try {
-            await access(`${application.solutionName}.sln`);
-          } catch {
-            await this.spawnCommand(`dotnet new sln --name ${application.solutionName}`);
-          }
+          solutionFile = await this.resolveSolutionFile(application.solutionName);
         } catch (err) {
           this.log.warn(`Failed to create ${application.solutionName} .Net Core solution: ${err}`);
         }
@@ -188,7 +185,7 @@ export default class extends BaseApplicationGenerator {
           `${CLIENT_TEST_DIR}${application.clientTestProject}${application.pascalizedBaseName}.Client.Test.csproj`,
         ];
 
-        await this.spawnCommand(`dotnet sln ${application.solutionName}.sln add ${projects.join(' ')}`);
+        await this.spawnCommand(`dotnet sln ${solutionFile} add ${projects.join(' ')}`);
         this.log(chalk.green.bold('Client application generated successfully.\n'));
         this.log(
           chalk.green(
@@ -224,5 +221,25 @@ export default class extends BaseApplicationGenerator {
         }
       },
     });
+  }
+
+  async resolveSolutionFile(solutionName) {
+    try {
+      await access(`${solutionName}.sln`);
+      return `${solutionName}.sln`;
+    } catch {
+      try {
+        await access(`${solutionName}.slnx`);
+        return `${solutionName}.slnx`;
+      } catch {
+        await this.spawnCommand(`dotnet new sln --name ${solutionName}`);
+        try {
+          await access(`${solutionName}.sln`);
+          return `${solutionName}.sln`;
+        } catch {
+          return `${solutionName}.slnx`;
+        }
+      }
+    }
   }
 }

--- a/generators/dotnetcore/templates/dotnetcore/src/Project/Project.csproj.ejs
+++ b/generators/dotnetcore/templates/dotnetcore/src/Project/Project.csproj.ejs
@@ -108,7 +108,7 @@
         </SonarQubeSetting>
     </ItemGroup>
 
-    <Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('$(RepoRoot)node_modules/.package-lock.json')">
+    <Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('$(RepoRoot)node_modules/.package-lock.json') Or !Exists('$(RepoRoot)node_modules/.bin/eslint')">
         <!-- Ensure Node.js is installed -->
         <Exec WorkingDirectory="$(RepoRoot)" Command="node --version" ContinueOnError="true">
             <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />

--- a/generators/dotnetcore/templates/dotnetcore/src/Project/Project.csproj.ejs
+++ b/generators/dotnetcore/templates/dotnetcore/src/Project/Project.csproj.ejs
@@ -108,7 +108,7 @@
         </SonarQubeSetting>
     </ItemGroup>
 
-    <Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('$(RepoRoot)node_modules')">
+    <Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('$(RepoRoot)node_modules/.package-lock.json')">
         <!-- Ensure Node.js is installed -->
         <Exec WorkingDirectory="$(RepoRoot)" Command="node --version" ContinueOnError="true">
             <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />

--- a/generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs
+++ b/generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs
@@ -160,6 +160,9 @@ function hasDateTimeTypeField(fields) {
 } _%>
 <%
 let hasDto = dto === 'mapstruct';
+const testedRelationships = databaseType !== 'mongodb'
+    ? relationships.filter(relationship => relationship.relationshipType === 'many-to-one' || relationship.relationshipType === 'one-to-one')
+    : [];
 %>
 <%_ if (hasDto) { _%>
 using AutoMapper;
@@ -211,6 +214,9 @@ namespace <%= namespace %>.Test.Controllers
             _client = _factory.CreateClient();
 
             _<%= camelCasedEntityClass %>Repository = _factory.GetRequiredService<I<%= pascalizedEntityClass %>Repository>();
+            <%_ testedRelationships.forEach(relationship => { _%>
+            _<%= relationship.relationshipFieldName %>Repository = _factory.GetRequiredService<I<%= relationship.otherEntityNamePascalized %>Repository>();
+            <%_ }); _%>
 
             <%_ if (hasDto) { _%>
             var config = new MapperConfiguration(cfg =>
@@ -241,6 +247,9 @@ namespace <%= namespace %>.Test.Controllers
         private readonly AppWebApplicationFactory<TestStartup> _factory;
         private readonly HttpClient _client;
         private readonly I<%= pascalizedEntityClass %>Repository _<%= camelCasedEntityClass %>Repository;
+        <%_ testedRelationships.forEach(relationship => { _%>
+        private readonly I<%= relationship.otherEntityNamePascalized %>Repository _<%= relationship.relationshipFieldName %>Repository;
+        <%_ }); _%>
 
         private <%= pascalizedEntityClass %> _<%= camelCasedEntityClass %>;
 
@@ -248,7 +257,7 @@ namespace <%= namespace %>.Test.Controllers
         private readonly IMapper _mapper;
         <%_ } _%>
 
-        private <%= pascalizedEntityClass %> CreateEntity()
+        public static <%= pascalizedEntityClass %> CreateEntity()
         {
             return new <%= pascalizedEntityClass %>
             {
@@ -271,10 +280,26 @@ namespace <%= namespace %>.Test.Controllers
             _<%= camelCasedEntityClass %> = CreateEntity();
         }
 
+        <%_ testedRelationships.forEach(relationship => { _%>
+        private async Task<<%= relationship.otherEntityNamePascalized %>> Create<%= relationship.relationshipFieldNamePascalized %>RelationshipEntity()
+        {
+            var <%= relationship.otherEntityNameLowerCased %> = <%= relationship.otherEntityNamePascalizedPlural %>ControllerIntTest.CreateEntity();
+            await _<%= relationship.relationshipFieldName %>Repository.CreateOrUpdateAsync(<%= relationship.otherEntityNameLowerCased %>);
+            await _<%= relationship.relationshipFieldName %>Repository.SaveChangesAsync();
+            return <%= relationship.otherEntityNameLowerCased %>;
+        }
+
+        <%_ }); _%>
+
         [Fact]
         public async Task Create<%= pascalizedEntityClass %>()
         {
             var databaseSizeBeforeCreate = await _<%= camelCasedEntityClass %>Repository.CountAsync();
+            <%_ testedRelationships.forEach(relationship => { _%>
+            var <%= relationship.relationshipFieldName %> = await Create<%= relationship.relationshipFieldNamePascalized %>RelationshipEntity();
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = <%= relationship.relationshipFieldName %>;
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id = <%= relationship.relationshipFieldName %>.Id;
+            <%_ }); _%>
 
             // Create the <%= pascalizedEntityClass %>
             <%_ if (hasDto) { _%>
@@ -292,6 +317,9 @@ namespace <%= namespace %>.Test.Controllers
             <%_ fields.forEach(field => {
                 if (field.id) return; _%>
             test<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %>.Should().Be(Default<%= field.fieldNamePascalized %>);
+            <%_ }); _%>
+            <%_ testedRelationships.forEach(relationship => { _%>
+            test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id.Should().Be(<%= relationship.relationshipFieldName %>.Id);
             <%_ }); _%>
         }
 
@@ -398,6 +426,11 @@ namespace <%= namespace %>.Test.Controllers
         public async Task Update<%= pascalizedEntityClass %>()
         {
             // Initialize the database
+            <%_ testedRelationships.forEach(relationship => { _%>
+            var <%= relationship.relationshipFieldName %> = await Create<%= relationship.relationshipFieldNamePascalized %>RelationshipEntity();
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = <%= relationship.relationshipFieldName %>;
+            _<%= camelCasedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id = <%= relationship.relationshipFieldName %>.Id;
+            <%_ }); _%>
             await _<%= camelCasedEntityClass %>Repository.CreateOrUpdateAsync(_<%= camelCasedEntityClass %>);
             await _<%= camelCasedEntityClass %>Repository.SaveChangesAsync();
             var databaseSizeBeforeUpdate = await _<%= camelCasedEntityClass %>Repository.CountAsync();
@@ -409,6 +442,11 @@ namespace <%= namespace %>.Test.Controllers
             <%_ fields.forEach(field => {
                 if (field.id) return; _%>
             updated<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %> = Updated<%= field.fieldNamePascalized %>;
+            <%_ }); _%>
+            <%_ testedRelationships.forEach(relationship => { _%>
+            var updated<%= relationship.relationshipFieldNamePascalized %> = await Create<%= relationship.relationshipFieldNamePascalized %>RelationshipEntity();
+            updated<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %> = updated<%= relationship.relationshipFieldNamePascalized %>;
+            updated<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id = updated<%= relationship.relationshipFieldNamePascalized %>.Id;
             <%_ }); _%>
 
             <%_ if (hasDto) { _%>
@@ -433,6 +471,9 @@ namespace <%= namespace %>.Test.Controllers
             test<%= pascalizedEntityClass %>.<%= field.fieldNamePascalized %>.Should().Be(Updated<%= field.fieldNamePascalized %>);
                 <%_ }
             }); _%>
+            <%_ testedRelationships.forEach(relationship => { _%>
+            test<%= pascalizedEntityClass %>.<%= relationship.relationshipFieldNamePascalized %>Id.Should().Be(updated<%= relationship.relationshipFieldNamePascalized %>.Id);
+            <%_ }); _%>
         }
 
         [Fact]

--- a/test-integration/scripts/04-generate-entities-sample.sh
+++ b/test-integration/scripts/04-generate-entities-sample.sh
@@ -33,3 +33,7 @@ if [[ "$2" = "import-jdl" ]]; then
   fi
 fi
 
+if [[ "$3" != "blazor" && -f package.json && -d src/JhipsterSampleApplication/ClientApp && ! -x node_modules/.bin/eslint ]]; then
+  echo "*** installing generated client dependencies"
+  npm install
+fi


### PR DESCRIPTION
## Issue
Closes #397

## Summary
Adds generated controller integration coverage for single-valued related entities. The template now creates related entities for many-to-one and one-to-one relationships, asserts create persists the relationship id, and asserts update can move the relationship to another entity.

## Checks
- [x] Tests are added where necessary
- [x] npm run ejslint -- generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs
- [x] npm run prettier-check -- generators/dotnetcore/templates/dotnetcore/test/Project.Test/Controllers/_persistClass_ControllerIntTest.cs.ejs
- [x] npm test -- --run generators/dotnetcore/generator.spec.js